### PR TITLE
Workflow improvements

### DIFF
--- a/gui/src/browserwidget.cc
+++ b/gui/src/browserwidget.cc
@@ -375,6 +375,9 @@ void BrowserWidget::onMutationSelectionChanged(const QItemSelection &selected, c
         for (auto result : database->getMutationResults(mutationId)) {
             addProperty(resItem, QVariant::String, result.first, result.second);
         }
+        bool ok;
+        QStringList param = source.split(':');
+        Q_EMIT selectLine(param.at(0), param.at(1));
     }
 }
 
@@ -399,9 +402,7 @@ void BrowserWidget::onMutationDoubleClicked(QTreeWidgetItem *item, int column)
     if (item->parent() == nullptr)
         return;
 
-    bool ok;
-    QStringList param = item->text(0).split(':');
-    Q_EMIT selectLine(param.at(0), param.at(1));
+    selectSource(item->text(0));
 }
 
 void BrowserWidget::onPropertyDoubleClicked(QTreeWidgetItem *item, int column)

--- a/gui/src/browserwidget.cc
+++ b/gui/src/browserwidget.cc
@@ -324,6 +324,9 @@ void BrowserWidget::onSourceSelectionChanged(const QItemSelection &selected, con
         for (auto result : database->getMutationResults(mutationId)) {
             addProperty(resItem, QVariant::String, result.first, result.second);
         }
+    } else {
+        QStringList param = source.split(':');
+        Q_EMIT selectLine(param.at(0), param.at(1));
     }
 }
 
@@ -392,9 +395,8 @@ void BrowserWidget::onSourceDoubleClicked(QTreeWidgetItem *item, int column)
     if (item->parent()->parent() != nullptr) {
         source = item->parent()->data(0, Qt::UserRole).toString();
         mut = item->data(0, Qt::UserRole).toString();
+        selectMutation(mut);
     }
-    QStringList param = source.split(':');
-    Q_EMIT selectLine(param.at(0), param.at(1));
 }
 
 void BrowserWidget::onMutationDoubleClicked(QTreeWidgetItem *item, int column)
@@ -431,6 +433,22 @@ void BrowserWidget::selectSource(QString source)
     }
 }
 
+void BrowserWidget::selectMutation(QString mutation)
+{
+    QTreeWidgetItemIterator it(mutationsList);
+    while (*it) {
+        QString val = (*it)->data(0, Qt::UserRole).toString();
+        if (val == mutation) {
+            if (tabWidget->currentWidget() != mutationsList) {
+                ((QTreeWidget *)tabWidget->currentWidget())->selectionModel()->clearSelection();
+                tabWidget->setCurrentWidget(mutationsList);
+            }
+            mutationsList->setCurrentItem(*it, 0, QItemSelectionModel::ClearAndSelect);
+            break;
+        }
+        ++it;
+    }
+}
 bool BrowserWidget::eventFilter(QObject *obj, QEvent *event)
 {
     if (obj == sourceList) {

--- a/gui/src/browserwidget.h
+++ b/gui/src/browserwidget.h
@@ -65,6 +65,7 @@ class BrowserWidget : public QWidget
 
   public Q_SLOTS:
     void selectSource(QString source);
+    void selectMutation(QString mutation);
 
   Q_SIGNALS:
     void selectLine(QString filename, QString line);

--- a/gui/src/main.cc
+++ b/gui/src/main.cc
@@ -47,19 +47,18 @@ int main(int argc, char *argv[])
         location = positionalArguments[0];
     }
     if (boost::filesystem::exists(location.toStdString())) {
-        if (!boost::filesystem::is_directory(location.toStdString())) {
-            printf("File location is not directory.\n");
-            return -1;
-        }
-        boost::filesystem::path path = boost::filesystem::path(location.toStdString()) / "database";
-        if (!boost::filesystem::exists(path)) {
-            printf("Database directory does not exists.\n");
-            return -1;
-        }
-        path /= "db.sqlite3";
-        if (!boost::filesystem::exists(path)) {
-            printf("Database file does not exists.\n");
-            return -1;
+        if (boost::filesystem::is_directory(location.toStdString())) {
+            boost::filesystem::path path = boost::filesystem::path(location.toStdString()) / "database";
+            if (!boost::filesystem::exists(path)) {
+                printf("Database directory does not exists.\n");
+                return -1;
+            }
+            path /= "db.sqlite3";
+            if (!boost::filesystem::exists(path)) {
+                printf("Database file does not exists.\n");
+                return -1;
+            }
+            location = path.string().c_str();
         }
     } else {
         printf("File location does not exists.\n");

--- a/gui/src/mainwindow.cc
+++ b/gui/src/mainwindow.cc
@@ -28,8 +28,8 @@
 
 static void initBasenameResource() { Q_INIT_RESOURCE(base); }
 
-MainWindow::MainWindow(QString workingDir, QString sourceDir, QWidget *parent)
-        : QMainWindow(parent), database(workingDir + "/database/db.sqlite3"), sourceDir(sourceDir)
+MainWindow::MainWindow(QString dbFile, QString sourceDir, QWidget *parent)
+        : QMainWindow(parent), database(dbFile), sourceDir(sourceDir)
 {
     initBasenameResource();
     qRegisterMetaType<std::string>();

--- a/gui/src/mainwindow.cc
+++ b/gui/src/mainwindow.cc
@@ -134,11 +134,9 @@ void MainWindow::openCodeViewTab(QString filename)
         code->setCoverage(database.getCoverage(filename), database.getLinesYetToCover(filename));
         views.insert(filename, code);
         centralTabWidget->addTab(code, QIcon(":/icons/resources/page_white_text.png"), filename);
-        connect(code, &CodeView::updateUi, [=](int updated) {
-            QString source = filename + ":" + QString::number(code->lineFromPosition(code->currentPos()) + 1);
-            browser->selectSource(source);
-        });
         connect(code, &ScintillaEdit::marginClicked, [=](int position, int modifiers, int margin) {
+            QString source = filename + ":" + QString::number(code->lineFromPosition(position) + 1);
+            browser->selectSource(source);
             code->selectLine(QString::number(code->lineFromPosition(position) + 1));
         });
     }

--- a/gui/src/mainwindow.h
+++ b/gui/src/mainwindow.h
@@ -37,7 +37,7 @@ class MainWindow : public QMainWindow
     Q_OBJECT
 
   public:
-    explicit MainWindow(QString workingDir, QString sourceDir, QWidget *parent = 0);
+    explicit MainWindow(QString dbFile, QString sourceDir, QWidget *parent = 0);
     virtual ~MainWindow();
 
   protected:


### PR DESCRIPTION
Some features to improve ease of use with mcy-gui:
 - enable db file to be loaded directly (as parameter to mcy-gui command)
 - select source line when just selecting item in mutation or source  tree
 - double click source item in mutation tree move user to source tree
 - double click mutation item in source tree move user to mutation tree
