### PR TITLE
add a [setup] section to execute an arbitrary script at init

### DIFF
--- a/docs/source/cmds.rst
+++ b/docs/source/cmds.rst
@@ -8,7 +8,7 @@ Command Reference
 	> mcy help
 
 	Usage:
-		mcy [--trace] init
+		mcy [--trace] init [--nosetup]
 		mcy [--trace] reset
 		mcy [--trace] status
 		mcy [--trace] list [--details] [<id_or_tag>..]
@@ -22,8 +22,8 @@ Command Reference
 
 All commands require the project configuration file ``config.mcy`` to be present in the current directory.
 
-mcy init
-	This command initializes the mcy database. It prepares the design using the script from the ``[script]`` section in ``config.mcy``, and generates a list of mutations conforming to the settings in the ``[options]`` section. It queues all mutations to be tested when ``mcy run`` is called.
+mcy init [--nosetup]
+	This command initializes the mcy database. It runs the optional setup script from the ``[setup]`` section in ``config.mcy`` first, then prepares the design using the script from the ``[script]`` section, and generates a list of mutations conforming to the settings in the ``[options]`` section. It queues all mutations to be tested when ``mcy run`` is called.
 	The command fails if the ``database`` directory exists. Run ``mcy purge`` to delete this directory if it is present.
 
 mcy reset

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -22,16 +22,26 @@ This section contains various configuration options for the mutation generation 
 
 	.. note:: The ``select`` keyword here is not the Yosys ``select`` command. The argument ``<selection>`` is used as the optional selection argument to the Yosys ``mutate`` command. While the selection pattern format is identical, you cannot use select subcommands such as ``-module``.
 
-Mutation generation options: for a description of how these values influence the mutation generation algorithm, see :ref:`mutgen`.
+Mutation generation options: ``mcy`` attempts to distribute mutations into all parts of the design. The documentation section :ref:`mutgen` describes the mutation generation algorithm, and how these values affect it.
 
 ``weight_cover``
-	Optional. Default: 500
+	Optional. Weight for source location coverage. See :ref:`mutgen` for details. Default: 500
 
-``weight_pq_w weight_pq_b weight_pq_c weight_pq_s weight_pq_mw weight_pq_mb weight_pq_mc weight_pq_ms``
-	Optional. Default: 100
+``weight_pq_w weight_pq_b weight_pq_c weight_pq_s``
+	Optional. Weights for the per-design wire/bit/cell/src queues.
+	See :ref:`mutgen` for details. Default: 100
+
+``weight_pq_mw weight_pq_mb weight_pq_mc weight_pq_ms``
+	Optional. Weights for the per-module wire/bit/cell/src queues.
+	See :ref:`mutgen` for details. Default: 100
 
 ``pick_cover_prcnt``
-	Optional. Default: 80
+	Optional. Chance that source location coverage influences which queue item is picked. See :ref:`mutgen` for details. Default: 80
+
+``[setup]``
+-----------
+
+Optional. This section can contain a bash script to be executed at the beginning of ``mcy init``, which is useful for various setup tasks that only need to be done once for use in the design and/or tests. This script is executed in the base project directory (where ``config.mcy`` is located).
 
 ``[script]``
 ------------

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -41,7 +41,9 @@ Mutation generation options: ``mcy`` attempts to distribute mutations into all p
 ``[setup]``
 -----------
 
-Optional. This section can contain a bash script to be executed at the beginning of ``mcy init``, which is useful for various setup tasks that only need to be done once for use in the design and/or tests. This script is executed in the base project directory (where ``config.mcy`` is located).
+Optional. This section can contain a bash script to be executed at the beginning of ``mcy init``, before the design is elaborated using the ``[script]`` section, which is useful for various setup tasks that only need to be done once for use in the design and/or tests. This script is executed in the base project directory (where ``config.mcy`` is located).
+
+Execution of this script can be skipped with ``mcy init --nosetup``.
 
 ``[script]``
 ------------

--- a/docs/source/mutate.rst
+++ b/docs/source/mutate.rst
@@ -5,7 +5,7 @@ The first step in any test script is to obtain the mutated module to run the tes
 
 There are three configurations that are commonly used:
 
-1. Permanently enabled single mutation. Applying a single mutation without any control options results in a module with he same interface as the original module that can be substituted in a testbench without requiring any modifications. This is generally the most straightforward way to run the testsuite that is being evaluated.
+1. Permanently enabled single mutation. Applying a single mutation without any control options results in a module with the same interface as the original module that can be substituted in a testbench without requiring any modifications. This is generally the most straightforward way to run the testsuite that is being evaluated.
 
 2. Selectable single mutation. Applying a single mutation with a control signal results in a module with one additional input, ``mutsel``. The mutation will be enabled if ``mutsel==1`` and disabled if ``mutsel==0``. Generally used in the equivalence test, where the same module can be instantiated twice with different ``mutsel`` inputs. This avoids problems with module name collision between the original and mutated version, and allows the use of ``fmcombine`` which can speed up the formal property solver.
 

--- a/mcy.py
+++ b/mcy.py
@@ -45,7 +45,7 @@ signal.signal(signal.SIGTERM, force_shutdown)
 def usage():
     print()
     print("Usage:")
-    print("  mcy [--trace] init")
+    print("  mcy [--trace] init [--nosetup]")
     print("  mcy [--trace] reset")
     print("  mcy [--trace] status")
     print("  mcy [--trace] list [--details] [<id_or_tag>..]")
@@ -380,13 +380,15 @@ class Task:
 
 if sys.argv[1] == "init":
     try:
-        opts, args = getopt.getopt(sys.argv[2:], "", [])
+        opts, args = getopt.getopt(sys.argv[2:], "", ["nosetup"])
     except getopt.GetoptError as err:
         print(err)
         usage()
 
+    dosetup = True
     for o, a in opts:
-        pass
+        if o == "--nosetup":
+            dosetup = False
 
     if os.path.exists("database"):
         print("found existing database/ directory.")
@@ -395,7 +397,7 @@ if sys.argv[1] == "init":
     print("creating database directory")
     os.mkdir("database")
 
-    if cfg.setup:
+    if dosetup and cfg.setup:
         print("running setup")
         with open("database/setup.sh", "w") as f:
             for line in cfg.setup:

--- a/mcy.py
+++ b/mcy.py
@@ -81,6 +81,7 @@ cfg.opt_size = 20
 cfg.opt_tags = None
 cfg.opt_seed = None
 cfg.mutopts = dict()
+cfg.setup = list()
 cfg.script = list()
 cfg.logic = list()
 cfg.report = list()
@@ -98,7 +99,7 @@ with open("config.mcy", "r") as f:
         match = re.match(r"^\[(.*)\]\s*$", line)
         if match:
             entries = match.group(1).split()
-            if len(entries) == 1 and entries[0] in ("options", "script", "logic", "report", "files"):
+            if len(entries) == 1 and entries[0] in ("options", "script", "setup", "logic", "report", "files"):
                 section, sectionarg = entries[0], None
                 continue
             if len(entries) == 2 and entries[0] == "test":
@@ -129,6 +130,10 @@ with open("config.mcy", "r") as f:
             if len(entries) > 1 and entries[0] == "select":
                 cfg.select += entries[1:]
                 continue
+
+        if section == "setup":
+            cfg.setup.append(line.rstrip())
+            continue
 
         if section == "script":
             cfg.script.append(line.rstrip())
@@ -389,6 +394,14 @@ if sys.argv[1] == "init":
 
     print("creating database directory")
     os.mkdir("database")
+
+    if cfg.setup:
+        print("running setup")
+        with open("database/setup.sh", "w") as f:
+            for line in cfg.setup:
+                print(line, file=f)
+        task = Task("bash database/setup.sh")
+        task.wait()
 
     with open("database/design.ys", "w") as f:
         for line in cfg.script:


### PR DESCRIPTION
For things that only need to be done once, not on a per-task basis. I need to create some shared artifacts for the tests to use. Other use cases might be code generators that need to be run to generate the files that yosys reads, so this section is executed before `[script]`.

(Also includes some documentation fixes I forgot to commit separately, oops.)