### PR TITLE
run setup inside database dir; add init -f option so --nosetup still works

### DIFF
--- a/docs/source/cmds.rst
+++ b/docs/source/cmds.rst
@@ -22,9 +22,10 @@ Command Reference
 
 All commands require the project configuration file ``config.mcy`` to be present in the current directory.
 
-mcy init [--nosetup]
+mcy init [-f] [--nosetup]
 	This command initializes the mcy database. It runs the optional setup script from the ``[setup]`` section in ``config.mcy`` first, then prepares the design using the script from the ``[script]`` section, and generates a list of mutations conforming to the settings in the ``[options]`` section. It queues all mutations to be tested when ``mcy run`` is called.
-	The command fails if the ``database`` directory exists. Run ``mcy purge`` to delete this directory if it is present.
+	The command fails if the ``database`` directory exists. Run ``mcy purge`` to delete this directory if it is present, or pass ``-f`` to force overwriting the contents.
+	The ``--nosetup`` option skips running the setup section. In combination, ``mcy init -f --nosetup`` allows re-initializing the project without re-running the setup script. This is useful when the configuration file was changed, but the setup script's output does not need to be re-generated.
 
 mcy reset
 	This command will reset various state. If the ``size`` parameter in the section ``[options]`` of ``config.mcy`` was increased, it will create additional mutations. It will re-run the tagging logic of the ``[logic]`` section and re-tag all mutations for which results are cached in the database. It queues the mutations for which results are not available to be tested when ``mcy run`` is called. It will also delete an existing ``tasks`` directory.

--- a/docs/source/cmds.rst
+++ b/docs/source/cmds.rst
@@ -25,7 +25,7 @@ All commands require the project configuration file ``config.mcy`` to be present
 mcy init [-f] [--nosetup]
 	This command initializes the mcy database. It runs the optional setup script from the ``[setup]`` section in ``config.mcy`` first, then prepares the design using the script from the ``[script]`` section, and generates a list of mutations conforming to the settings in the ``[options]`` section. It queues all mutations to be tested when ``mcy run`` is called.
 	The command fails if the ``database`` directory exists. Run ``mcy purge`` to delete this directory if it is present, or pass ``-f`` to force overwriting the contents.
-	The ``--nosetup`` option skips running the setup section. In combination, ``mcy init -f --nosetup`` allows re-initializing the project without re-running the setup script. This is useful when the configuration file was changed, but the setup script's output does not need to be re-generated.
+	The ``--nosetup`` option skips running the setup section. In combination, ``mcy init -f --nosetup`` allows re-initializing the project without deleting the files present in ``database/setup``. This is useful when the configuration file was changed, but the setup script's output does not need to be re-generated.
 
 mcy reset
 	This command will reset various state. If the ``size`` parameter in the section ``[options]`` of ``config.mcy`` was increased, it will create additional mutations. It will re-run the tagging logic of the ``[logic]`` section and re-tag all mutations for which results are cached in the database. It queues the mutations for which results are not available to be tested when ``mcy run`` is called. It will also delete an existing ``tasks`` directory.

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -41,7 +41,7 @@ Mutation generation options: ``mcy`` attempts to distribute mutations into all p
 ``[setup]``
 -----------
 
-Optional. This section can contain a bash script to be executed at the beginning of ``mcy init``, before the design is elaborated using the ``[script]`` section, which is useful for various setup tasks that only need to be done once for use in the design and/or tests. This script is executed in the base project directory (where ``config.mcy`` is located).
+Optional. This section can contain a bash script to be executed at the beginning of ``mcy init``, before the design is elaborated using the ``[script]`` section, which is useful for various setup tasks that only need to be done once for use in the design and/or tests. This script is executed in the ``database/setup`` directory. (This directory is deleted when ``mcy purge`` is run.)
 
 Execution of this script can be skipped with ``mcy init --nosetup``.
 

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -41,7 +41,8 @@ Mutation generation options: ``mcy`` attempts to distribute mutations into all p
 ``[setup]``
 -----------
 
-Optional. This section can contain a bash script to be executed at the beginning of ``mcy init``, before the design is elaborated using the ``[script]`` section, which is useful for various setup tasks that only need to be done once for use in the design and/or tests. This script is executed in the ``database/setup`` directory. (This directory is deleted when ``mcy purge`` is run.)
+Optional. This section can contain a bash script to be executed at the beginning of ``mcy init``, before the design is elaborated using the ``[script]`` section, which is useful for various setup tasks that only need to be done once for use in the design and/or tests. This script is executed in the base project directory (where ``config.mcy`` is located).
+If you would like the files created by the setup script to be managed by mcy and deleted when ``mcy purge`` is run, you can write them to the directory ``database/setup``, which is created before the setup script runs.
 
 Execution of this script can be skipped with ``mcy init --nosetup``.
 

--- a/mcy.py
+++ b/mcy.py
@@ -380,26 +380,38 @@ class Task:
 
 if sys.argv[1] == "init":
     try:
-        opts, args = getopt.getopt(sys.argv[2:], "", ["nosetup"])
+        opts, args = getopt.getopt(sys.argv[2:], "f", ["nosetup"])
     except getopt.GetoptError as err:
         print(err)
         usage()
 
     dosetup = True
+    force = False
     for o, a in opts:
         if o == "--nosetup":
             dosetup = False
+        if o == "-f":
+            force = True
 
     if os.path.exists("database"):
-        print("found existing database/ directory.")
-        exit(1)
-
-    print("creating database directory")
-    os.mkdir("database")
+        if not force:
+            print("found existing database/ directory.")
+            exit(1)
+        else:
+            try:
+                os.remove("database/db.sqlite3")
+            except FileNotFoundError:
+                pass
+    else:
+        print("creating database directory")
+        os.mkdir("database")
 
     if dosetup and cfg.setup:
         print("running setup")
+        if not os.path.exists("database/setup"):
+            os.mkdir("database/setup")
         with open("database/setup.sh", "w") as f:
+            print("cd database/setup", file=f)
             for line in cfg.setup:
                 print(line, file=f)
         task = Task("bash database/setup.sh")

--- a/mcy.py
+++ b/mcy.py
@@ -411,7 +411,6 @@ if sys.argv[1] == "init":
         if not os.path.exists("database/setup"):
             os.mkdir("database/setup")
         with open("database/setup.sh", "w") as f:
-            print("cd database/setup", file=f)
             for line in cfg.setup:
                 print(line, file=f)
         task = Task("bash database/setup.sh")


### PR DESCRIPTION
This changes the `[setup]` section script to be executed inside `database/setup`, so that its results get removed with ``mcy purge``.

For ``mcy init --nosetup`` to still make sense, it adds a ``-f`` option that allows re-running ``mcy init`` with an existing ``database`` directory, which deletes only the db file and overwrites the other files touched.