### PR TITLE
add embed of youtube tutorial for html version

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -4,6 +4,10 @@ Tutorial
 
 This guide will explain how to set up a project from scratch using the bit-counter project in ``examples/bitcnt`` as an example. A shorter overview of the project is also available in `this youtube video`_.
 
+.. raw:: html
+
+		<iframe width="640" height="360" src="https://www.youtube.com/embed/NKzqRum1ksg" frameborder="0" allowfullscreen="1">&nbsp;</iframe>
+
 .. _this youtube video: https://youtu.be/NKzqRum1ksg
 
 You should start out with the following files:


### PR DESCRIPTION
The 'sphinxcontrib.youtube' extension is severely broken (last PyPI release only works on Python 2, current github master works on 3 but forgets to include `https:` at the beginning of the URL so doesn't show the video, and also causes any non-html build to error out so we wouldn't be able to have pdf export any more) so this does not use it. Instead, the youtube embed iframe is directly added as a `.. raw:: html` directive, which just gets ignored by `make latexpdf`.