### PR TITLE
master -> main

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MCY is a new tool to help digital designers and project managers understand and 
 
 *If you have a testbench, and it fails, you know you have a problem. But if it passes, you know nothing if you don’t know what your testbench is actually testing for.*
 
-![MCY Overview Diagram](https://github.com/YosysHQ/mcy/raw/master/docs/images/mcy.png)
+![MCY Overview Diagram](https://github.com/YosysHQ/mcy/raw/main/docs/images/mcy.png)
 
 Given a self checking testbench, MCY generates 1000s of mutations by modifying individual signals in a post synthesis netlist. These mutations are then filtered using Formal Verification techniques, keeping only those that can cause an important change in the design’s output.
 
@@ -12,11 +12,11 @@ All mutated designs are run against the testbench to check that the testbench wi
 
 `mcy gui` can be used to explore the results and find where coverage needs improvement.
 
-![MCY GUI Screenshot](https://github.com/YosysHQ/mcy/raw/master/docs/images/mcy-gui.png)
+![MCY GUI Screenshot](https://github.com/YosysHQ/mcy/raw/main/docs/images/mcy-gui.png)
 
 `mcy dash` provides at a glance overview as the tool runs. It is browser-based to easily take advantage of cloud compute.
 
-![MCY Dash Screenshot](https://github.com/YosysHQ/mcy/raw/master/docs/images/mcy-dash.png)
+![MCY Dash Screenshot](https://github.com/YosysHQ/mcy/raw/main/docs/images/mcy-dash.png)
 
 **For more information please contact contact@yosyshq.com**
 


### PR DESCRIPTION
This fixes the pictures on the Readme. Before github was unable to display them, since they were not there