### PR TITLE
build: Bump `CMAKE_MINIMUM_REQUIRED` to `3.13`

### DIFF
--- a/gui/3rdparty/QtPropertyBrowser/CMakeLists.txt
+++ b/gui/3rdparty/QtPropertyBrowser/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.11)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.13)
 PROJECT(QtPropertyBrowser)
 
 ##################### Look for required libraries ######################

--- a/gui/3rdparty/scintilla/CMakeLists.txt
+++ b/gui/3rdparty/scintilla/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.11)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.13)
 PROJECT(ScintillaEdit)
 
 FIND_PACKAGE(Qt5Widgets REQUIRED)
@@ -6,7 +6,7 @@ FIND_PACKAGE(Qt5Widgets REQUIRED)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-set(SCINTILLA_EDIT_SRC 
+set(SCINTILLA_EDIT_SRC
     qt/ScintillaEdit/ScintillaEdit.cpp
     qt/ScintillaEdit/ScintillaDocument.cpp
     qt/ScintillaEdit/ScintillaEdit.h

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -1,5 +1,5 @@
 # TODO: sensible minimum CMake version
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.13)
 project(mcy-gui)
 
 set(CMAKE_CXX_STANDARD 14)


### PR DESCRIPTION
This is a simple (and kinda hacky, tbh) PR to bump the minimum CMake version for mcy and its components to match that of nextpnr.

The MCY builds have started failing on Arch due to the vastly newer CMake, so this fixes that by using nextpnr's version as the minimum.