### PR TITLE
Add mcy to evaluate the SQED verification example for ridecore

### DIFF
--- a/examples/SQED_ridecore/.gitignore
+++ b/examples/SQED_ridecore/.gitignore
@@ -1,0 +1,1 @@
+database/

--- a/examples/SQED_ridecore/README.md
+++ b/examples/SQED_ridecore/README.md
@@ -1,0 +1,6 @@
+# This demo showcases Mutation Cover with Yosys (MCY)'s evaluation of Symbolic Quick Error Detection (SQED)'s ability to verify ridecore processor
+
+[ridecore](https://github.com/ridecore/ridecore.git) is a dual-issue, six-stage, out-of-order CPU with support for up to 64 instructions in flight, two ALUs, one multiplier, and one load/store unit, aimed at high-performance applications. 
+
+[SQED](https://github.com/upscale-project/generic-sqed-demo.git) is a transformative processors and hardware accelerators formal verification methodology that can check a design-independent universal property, reducing manual property development efforts. SQED employs bounded model checking (BMC) to formally verify the self-consistency property, which asserts that the execution of an original instruction and its duplicate produces the consistent outcome.   
+

--- a/examples/SQED_ridecore/config.mcy
+++ b/examples/SQED_ridecore/config.mcy
@@ -1,0 +1,158 @@
+[options]
+size 400
+weight_cover 500
+weight_pq_s 500
+weight_pq_ms 500
+pick_cover_prcnt 90
+tags COVERED UNCOVERED NOCHANGE EQGAP 
+
+
+[script]
+read_verilog -sv rtl/design/define.v \
+rtl/design/top_ridecore.v \
+rtl/design/alloc_issue_ino.v \
+rtl/design/search_be.v \
+rtl/design/srcsel.v  \
+rtl/design/alu_ops.vh \
+rtl/design/arf.v \
+rtl/design/ram_sync.v \
+rtl/design/ram_sync_nolatch.v  \
+rtl/design/brimm_gen.v \
+rtl/design/constants.vh \
+rtl/design/decoder.v \
+rtl/design/dmem.v \
+rtl/design/exunit_alu.v \
+rtl/design/exunit_branch.v \
+rtl/design/exunit_ldst.v \
+rtl/design/exunit_mul.v \
+rtl/design/imem.v \
+rtl/design/imm_gen.v \
+rtl/design/pipeline_if.v \
+rtl/design/gshare.v \
+rtl/design/pipeline.v \
+rtl/design/oldest_finder.v \
+rtl/design/btb.v \
+rtl/design/prioenc.v \
+rtl/design/mpft.v \
+rtl/design/reorderbuf.v \
+rtl/design/rrf_freelistmanager.v \
+rtl/design/rrf.v \
+rtl/design/rs_alu.v \
+rtl/design/rs_branch.v \
+rtl/design/rs_ldst.v \
+rtl/design/rs_mul.v \
+rtl/design/rs_reqgen.v \
+rtl/design/rv32_opcodes.vh \
+rtl/design/src_manager.v \
+rtl/design/srcopr_manager.v \
+rtl/design/storebuf.v \
+rtl/design/tag_generator.v \
+rtl/design/dualport_ram.v \
+rtl/design/alu.v \
+rtl/design/multiplier.v ;
+
+# prep does a conservative elaboration of the top module provided
+prep -top top_ridecore;
+
+# this command just does a sanity check of the hierarchy
+hierarchy -check; 
+
+# translate processes to netlists
+proc;
+
+# flatten the design hierarchy
+flatten;
+
+# this processes memories
+# nomap means it will keep them as arrays
+memory;
+
+# This turns all undriven signals into inputs
+setundef -undriven -expose;
+
+
+[files]
+rtl/design/define.v 
+rtl/design/top_ridecore.v 
+rtl/design/alloc_issue_ino.v 
+rtl/design/search_be.v 
+rtl/design/srcsel.v  
+rtl/design/alu_ops.vh 
+rtl/design/arf.v 
+rtl/design/ram_sync.v 
+rtl/design/ram_sync_nolatch.v  
+rtl/design/brimm_gen.v 
+rtl/design/constants.vh 
+rtl/design/decoder.v 
+rtl/design/dmem.v 
+rtl/design/exunit_alu.v 
+rtl/design/exunit_branch.v 
+rtl/design/exunit_ldst.v 
+rtl/design/exunit_mul.v 
+rtl/design/imem.v 
+rtl/design/imm_gen.v 
+rtl/design/pipeline_if.v 
+rtl/design/gshare.v 
+rtl/design/pipeline.v 
+rtl/design/oldest_finder.v 
+rtl/design/btb.v 
+rtl/design/prioenc.v 
+rtl/design/mpft.v 
+rtl/design/reorderbuf.v 
+rtl/design/rrf_freelistmanager.v 
+rtl/design/rrf.v 
+rtl/design/rs_alu.v 
+rtl/design/rs_branch.v 
+rtl/design/rs_ldst.v 
+rtl/design/rs_mul.v 
+rtl/design/rs_reqgen.v 
+rtl/design/rv32_opcodes.vh 
+rtl/design/src_manager.v 
+rtl/design/srcopr_manager.v 
+rtl/design/storebuf.v 
+rtl/design/tag_generator.v 
+rtl/design/dualport_ram.v 
+rtl/design/alu.v 
+rtl/design/multiplier.v 
+
+
+[logic]
+use_formal = True
+
+eq_okay = ((result("test_eq") == "PASS") or (result("test_eq") == "TIMEOUT"))
+tb_fail = ((result("fm_btor") == "FAIL") or (result("fm_smtbmc 7200") == "FAIL"))
+
+if not tb_fail and not eq_okay:
+    tag("UNCOVERED")
+elif tb_fail and not eq_okay:
+    tag("COVERED")
+elif not tb_fail and eq_okay:
+    tag("NOCHANGE")
+elif tb_fail and eq_okay:
+    tag("EQGAP")
+else:
+    assert 0
+    
+
+[report]
+if tags("EQGAP"):
+    print("Found %d mutations exposing a formal gap!" % tags("EQGAP"))
+if tags("COVERED")+tags("UNCOVERED"):
+    print("Coverage: %.2f%%" % (100.0*tags("COVERED")/(tags("COVERED")+tags("UNCOVERED"))))
+if tags():
+    print("Nochange mutation percentage: %.2f%%" % (100.0*tags("NOCHANGE")/(tags())))
+
+
+[test test_eq]
+expect PASS FAIL TIMEOUT
+run bash $PRJDIR/test_eq.sh
+
+
+[test fm_btor]
+expect PASS FAIL TIMEOUT
+run bash $PRJDIR/fm_btor.sh
+
+
+[test fm_smtbmc]
+expect PASS FAIL TIMEOUT
+run bash $PRJDIR/fm_smtbmc.sh

--- a/examples/SQED_ridecore/fm_btor.sby
+++ b/examples/SQED_ridecore/fm_btor.sby
@@ -1,0 +1,40 @@
+[options]
+mode bmc
+depth 13
+timeout 7200
+expect pass,fail,timeout
+
+
+[engines]
+btor pono
+
+
+[script]
+read_verilog -sv test_fm.sv inst_constraints.v modify_instruction.v properties.v qed_decoder.v qed_i_cache.v qed_instruction_mux.v qed.v 
+#read_ilang mutated.il
+read_rtlil mutated.il
+#clk2fflogic
+async2sync
+chformal -lower
+chformal -assume -early
+prep -top testbench
+hierarchy -check
+proc
+flatten
+memory
+opt -fast
+dffunmap
+sim -clock din_clk -resetn din_rst_n -n 5 -rstlen 5 -zinit -w testbench
+setundef -undriven -expose
+
+
+[files]
+../../test_fm.sv
+../../rtl/qed_files/inst_constraints.v 
+../../rtl/qed_files/modify_instruction.v 
+../../rtl/qed_files/properties.v
+../../rtl/qed_files/qed_decoder.v 
+../../rtl/qed_files/qed_i_cache.v 
+../../rtl/qed_files/qed_instruction_mux.v
+../../rtl/qed_files/qed.v
+mutated.il

--- a/examples/SQED_ridecore/fm_btor.sh
+++ b/examples/SQED_ridecore/fm_btor.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+exec 2>&1
+set -ex
+
+# specify the path to the mutation export script
+SCRIPTS=/mnt/data/liyf/Computer-Architecture/model_checking/oss-cad-suite/share/mcy/scripts
+
+## create the mutated design
+bash $SCRIPTS/create_mutated.sh -o mutated.il
+
+## run formal property check
+ln -fs ../../fm_btor.sby .
+sby -f fm_btor.sby
+
+## obtain result
+gawk "{ print 1, \$1; }" fm_btor/status >> output.txt
+
+exit 0

--- a/examples/SQED_ridecore/fm_smtbmc.sby
+++ b/examples/SQED_ridecore/fm_smtbmc.sby
@@ -1,0 +1,41 @@
+[options]
+mode bmc
+depth 13
+timeout @TIMEOUT@
+expect pass,fail,timeout
+aigsmt none
+
+
+[engines]
+smtbmc yices
+
+
+[script]
+read_verilog -sv test_fm.sv inst_constraints.v modify_instruction.v properties.v qed_decoder.v qed_i_cache.v qed_instruction_mux.v qed.v 
+#read_ilang mutated.il
+read_rtlil mutated.il
+#clk2fflogic
+async2sync
+chformal -lower
+chformal -assume -early
+prep -top testbench
+hierarchy -check
+proc
+flatten
+memory
+opt -fast
+dffunmap
+sim -clock din_clk -resetn din_rst_n -n 5 -rstlen 5 -zinit -w testbench
+setundef -undriven -expose
+
+
+[files]
+../../test_fm.sv
+../../rtl/qed_files/inst_constraints.v 
+../../rtl/qed_files/modify_instruction.v 
+../../rtl/qed_files/properties.v
+../../rtl/qed_files/qed_decoder.v 
+../../rtl/qed_files/qed_i_cache.v 
+../../rtl/qed_files/qed_instruction_mux.v
+../../rtl/qed_files/qed.v
+mutated.il

--- a/examples/SQED_ridecore/fm_smtbmc.sh
+++ b/examples/SQED_ridecore/fm_smtbmc.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+exec 2>&1
+set -ex
+
+# specify the path to the mutation export script
+SCRIPTS=/mnt/data/liyf/Computer-Architecture/model_checking/oss-cad-suite/share/mcy/scripts
+
+## create the mutated design
+bash $SCRIPTS/create_mutated.sh -c -o mutated.il
+
+ln -fs ../../fm_smtbmc.sby .
+
+sed -i "s/@TIMEOUT@/$1/" fm_smtbmc.sby
+
+if [ $KEEPDIR = 1 ]; then
+	sed -i "/^aigsmt / d;" fm_smtbmc.sby
+fi
+
+sby -f fm_smtbmc.sby
+
+## obtain result
+gawk "{ print 1, \$1; }" fm_smtbmc/status >> output.txt
+
+exit 0

--- a/examples/SQED_ridecore/gen_ilang.ys
+++ b/examples/SQED_ridecore/gen_ilang.ys
@@ -1,0 +1,64 @@
+read_verilog -sv ./rtl/design/define.v \
+./rtl/design/top_ridecore.v \
+./rtl/design/alloc_issue_ino.v \
+./rtl/design/search_be.v \
+./rtl/design/srcsel.v  \
+./rtl/design/alu_ops.vh \
+./rtl/design/arf.v \
+./rtl/design/ram_sync.v \
+./rtl/design/ram_sync_nolatch.v  \
+./rtl/design/brimm_gen.v \
+./rtl/design/constants.vh \
+./rtl/design/decoder.v \
+./rtl/design/dmem.v \
+./rtl/design/exunit_alu.v \
+./rtl/design/exunit_branch.v \
+./rtl/design/exunit_ldst.v \
+./rtl/design/exunit_mul.v \
+./rtl/design/imem.v \
+./rtl/design/imm_gen.v \
+./rtl/design/pipeline_if.v \
+./rtl/design/gshare.v \
+./rtl/design/pipeline.v \
+./rtl/design/oldest_finder.v \
+./rtl/design/btb.v \
+./rtl/design/prioenc.v \
+./rtl/design/mpft.v \
+./rtl/design/reorderbuf.v \
+./rtl/design/rrf_freelistmanager.v \
+./rtl/design/rrf.v \
+./rtl/design/rs_alu.v \
+./rtl/design/rs_branch.v \
+./rtl/design/rs_ldst.v \
+./rtl/design/rs_mul.v \
+./rtl/design/rs_reqgen.v \
+./rtl/design/rv32_opcodes.vh \
+./rtl/design/src_manager.v \
+./rtl/design/srcopr_manager.v \
+./rtl/design/storebuf.v \
+./rtl/design/tag_generator.v \
+./rtl/design/dualport_ram.v \
+./rtl/design/alu.v \
+./rtl/design/multiplier.v 
+
+# prep does a conservative elaboration of the top module provided
+prep -top top_ridecore;
+
+# this command just does a sanity check of the hierarchy
+hierarchy -check;
+
+# translate processes to netlists
+proc;
+
+# flatten the design hierarchy
+flatten;
+
+# this processes memories
+# nomap means it will keep them as arrays
+memory;
+
+# This turns all undriven signals into inputs
+setundef -undriven -expose;
+
+# This writes to a file in ILANG format
+write_rtlil database/design.il

--- a/examples/SQED_ridecore/rtl/design/LICENSE
+++ b/examples/SQED_ridecore/rtl/design/LICENSE
@@ -1,0 +1,51 @@
+Copyright (c) 2016 Arch Lab. Tokyo Institute of Technology.
+All rights reserved. 
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+Copyright (c) 2015-2015, The Regents of the University of California
+(Regents).  All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the Regents nor the
+   names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING
+OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS
+BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
+HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
+MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.

--- a/examples/SQED_ridecore/rtl/design/alloc_issue_ino.v
+++ b/examples/SQED_ridecore/rtl/design/alloc_issue_ino.v
@@ -1,0 +1,97 @@
+`include "constants.vh"
+
+//`default_nettype none
+  
+module alloc_issue_ino  #(
+			  parameter ENTSEL = 2,
+			  parameter ENTNUM = 4
+			  )
+   (
+    input wire 		     clk,
+    input wire 		     reset,
+    input wire [1:0] 	     reqnum,
+    input wire [ENTNUM-1:0]  busyvec,
+    input wire [ENTNUM-1:0]  prbusyvec_next,
+    input wire [ENTNUM-1:0]  readyvec,
+    input wire 		     prmiss,
+    input wire 		     exunit_busynext,
+    input wire 		     stall_DP,
+    input wire 		     kill_DP,
+    output reg [ENTSEL-1:0]  allocptr,
+    output wire 	     allocatable,
+    output wire [ENTSEL-1:0] issueptr,
+    output wire 	     issuevalid
+   );
+
+
+   wire [ENTSEL-1:0] 	    allocptr2 = allocptr + 1;
+   wire [ENTSEL-1:0] 	    b0;
+   wire [ENTSEL-1:0] 	    e0;
+   wire [ENTSEL-1:0] 	    b1;
+   wire [ENTSEL-1:0] 	    e1;
+   wire 		    notfull;
+
+   wire [ENTSEL-1:0] 	    ne1;
+   wire [ENTSEL-1:0] 	    nb0;
+   wire [ENTSEL-1:0] 	    nb1;
+   wire 		    notfull_next;
+   
+   search_begin #(ENTSEL, ENTNUM) sb1(
+				      .in(busyvec),
+				      .out(b1),
+				      .en()
+				      );
+   
+   search_end #(ENTSEL, ENTNUM) se1(
+				    .in(busyvec),
+				    .out(e1),
+				    .en()
+				    );
+
+   search_end #(ENTSEL, ENTNUM) se0(
+				    .in(~busyvec),
+				    .out(e0),
+				    .en(notfull)
+				    );
+
+   search_begin #(ENTSEL, ENTNUM) snb1(
+				       .in(prbusyvec_next),
+				       .out(nb1),
+				       .en()
+				       );
+   
+   search_end #(ENTSEL, ENTNUM) sne1(
+				     .in(prbusyvec_next),
+				     .out(ne1),
+				     .en()
+				     );
+
+   search_begin #(ENTSEL, ENTNUM) snb0(
+				       .in(~prbusyvec_next),
+				       .out(nb0),
+				       .en(notfull_next)
+				       );
+
+   assign issueptr = ~notfull ? allocptr :
+		     ((b1 == 0) && (e1 == ENTNUM-1)) ? (e0+1) : 
+		     b1;
+   
+   assign issuevalid = readyvec[issueptr] & ~prmiss & ~exunit_busynext;
+
+   assign allocatable = (reqnum == 2'h0) ? 1'b1 :
+			(reqnum == 2'h1) ? ((~busyvec[allocptr] ? 1'b1 : 1'b0)) :
+			((~busyvec[allocptr] && ~busyvec[allocptr2]) ? 1'b1 : 1'b0);
+   
+   always @ (posedge clk) begin
+      if (reset) begin
+	 allocptr <= 0;
+      end else if (prmiss) begin
+	 allocptr <= ~notfull_next ? allocptr :
+		     (((nb1 == 0) && (ne1 == ENTNUM-1)) ? nb0 : (ne1+1));
+      end else if (~stall_DP && ~kill_DP) begin
+	 allocptr <= allocptr + reqnum;
+      end
+   end
+endmodule // alloc_issue_ino
+
+//`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/alu.v
+++ b/examples/SQED_ridecore/rtl/design/alu.v
@@ -1,0 +1,43 @@
+`include "alu_ops.vh"
+`include "rv32_opcodes.vh"
+
+`default_nettype none
+  
+module alu(
+           input wire [`ALU_OP_WIDTH-1:0] op,
+           input wire [`XPR_LEN-1:0] 	  in1,
+           input wire [`XPR_LEN-1:0] 	  in2,
+           output reg [`XPR_LEN-1:0] 	  out
+           );
+
+   wire [`SHAMT_WIDTH-1:0] 	     shamt;
+
+   assign shamt = in2[`SHAMT_WIDTH-1:0];
+
+   always @(*) begin
+      case (op)
+        // EDIT mutation: The addition operation is replaced with a subtraction operation
+        `ALU_OP_ADD : out = in1 + in2;
+        //`ALU_OP_ADD : out = in1 - in2; // Mutation: Change ADD to SUB
+        // END EDIT
+        `ALU_OP_SLL : out = in1 << shamt;
+        `ALU_OP_XOR : out = in1 ^ in2;
+        `ALU_OP_OR : out = in1 | in2;
+        `ALU_OP_AND : out = in1 & in2;
+        `ALU_OP_SRL : out = in1 >> shamt;
+        `ALU_OP_SEQ : out = {31'b0, in1 == in2};
+        `ALU_OP_SNE : out = {31'b0, in1 != in2};
+        `ALU_OP_SUB : out = in1 - in2;
+        `ALU_OP_SRA : out = $signed(in1) >>> shamt;
+        `ALU_OP_SLT : out = {31'b0, $signed(in1) < $signed(in2)};
+        `ALU_OP_SGE : out = {31'b0, $signed(in1) >= $signed(in2)};
+        `ALU_OP_SLTU : out = {31'b0, in1 < in2};
+        `ALU_OP_SGEU : out = {31'b0, in1 >= in2};
+        default : out = 0;
+      endcase // case op
+   end
+
+
+endmodule // alu
+
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/alu_ops.vh
+++ b/examples/SQED_ridecore/rtl/design/alu_ops.vh
@@ -1,0 +1,16 @@
+`define ALU_OP_WIDTH 4
+
+`define ALU_OP_ADD  `ALU_OP_WIDTH'd0
+`define ALU_OP_SLL  `ALU_OP_WIDTH'd1
+`define ALU_OP_XOR  `ALU_OP_WIDTH'd4
+`define ALU_OP_OR   `ALU_OP_WIDTH'd6
+`define ALU_OP_AND  `ALU_OP_WIDTH'd7
+`define ALU_OP_SRL  `ALU_OP_WIDTH'd5
+`define ALU_OP_SEQ  `ALU_OP_WIDTH'd8
+`define ALU_OP_SNE  `ALU_OP_WIDTH'd9
+`define ALU_OP_SUB  `ALU_OP_WIDTH'd10
+`define ALU_OP_SRA  `ALU_OP_WIDTH'd11
+`define ALU_OP_SLT  `ALU_OP_WIDTH'd12
+`define ALU_OP_SGE  `ALU_OP_WIDTH'd13
+`define ALU_OP_SLTU `ALU_OP_WIDTH'd14
+`define ALU_OP_SGEU `ALU_OP_WIDTH'd15

--- a/examples/SQED_ridecore/rtl/design/arf.v
+++ b/examples/SQED_ridecore/rtl/design/arf.v
@@ -1,0 +1,1127 @@
+`include "constants.vh"
+`default_nettype none
+module arf
+  (
+   input wire 			 clk,
+   input wire 			 reset,
+   input wire [`REG_SEL-1:0] 	 rs1_1, //DP from here
+   input wire [`REG_SEL-1:0] 	 rs2_1,
+   input wire [`REG_SEL-1:0] 	 rs1_2,
+   input wire [`REG_SEL-1:0] 	 rs2_2,
+   output wire [`DATA_LEN-1:0] 	 rs1_1data,
+   output wire [`DATA_LEN-1:0] 	 rs2_1data,
+   output wire [`DATA_LEN-1:0] 	 rs1_2data,
+   output wire [`DATA_LEN-1:0] 	 rs2_2data, //DP end 
+   input wire [`REG_SEL-1:0] 	 wreg1, //com_dst1
+   input wire [`REG_SEL-1:0] 	 wreg2, //com_dst2
+   input wire [`DATA_LEN-1:0] 	 wdata1, //com_data1
+   input wire [`DATA_LEN-1:0] 	 wdata2, //com_data2
+   input wire 			 we1, //com_en1
+   input wire 			 we2, //com_en2
+   input wire [`RRF_SEL-1:0] 	 wrrfent1, //comtag1
+   input wire [`RRF_SEL-1:0] 	 wrrfent2, //comtag2
+   output wire [`RRF_SEL-1:0] 	 rs1_1tag, // DP from here
+   output wire [`RRF_SEL-1:0] 	 rs2_1tag,
+   output wire [`RRF_SEL-1:0] 	 rs1_2tag,
+   output wire [`RRF_SEL-1:0] 	 rs2_2tag,
+   input wire [`REG_SEL-1:0] 	 tagbusy1_addr,
+   input wire [`REG_SEL-1:0] 	 tagbusy2_addr,
+   input wire 			 tagbusy1_we,
+   input wire 			 tagbusy2_we,
+   input wire [`RRF_SEL-1:0] 	 settag1,
+   input wire [`RRF_SEL-1:0] 	 settag2,
+   input wire [`SPECTAG_LEN-1:0] tagbusy1_spectag,
+   input wire [`SPECTAG_LEN-1:0] tagbusy2_spectag,
+   output wire 			 rs1_1busy,
+   output wire 			 rs2_1busy,
+   output wire 			 rs1_2busy,
+   output wire 			 rs2_2busy,
+   input wire 			 prmiss,
+   input wire 			 prsuccess,
+   input wire [`SPECTAG_LEN-1:0] prtag,
+   input wire [`SPECTAG_LEN-1:0] mpft_valid1,
+   input wire [`SPECTAG_LEN-1:0] mpft_valid2,
+   output wire [`DATA_LEN-1:0] mem0,
+   output wire [`DATA_LEN-1:0] mem1,
+   output wire [`DATA_LEN-1:0] mem2,
+   output wire [`DATA_LEN-1:0] mem3,
+   output wire [`DATA_LEN-1:0] mem4,
+   output wire [`DATA_LEN-1:0] mem5,
+   output wire [`DATA_LEN-1:0] mem6,
+   output wire [`DATA_LEN-1:0] mem7,
+   output wire [`DATA_LEN-1:0] mem8,
+   output wire [`DATA_LEN-1:0] mem9,
+   output wire [`DATA_LEN-1:0] mem10,
+   output wire [`DATA_LEN-1:0] mem11,
+   output wire [`DATA_LEN-1:0] mem12,
+   output wire [`DATA_LEN-1:0] mem13,
+   output wire [`DATA_LEN-1:0] mem14,
+   output wire [`DATA_LEN-1:0] mem15,
+   output wire [`DATA_LEN-1:0] mem16,
+   output wire [`DATA_LEN-1:0] mem17,
+   output wire [`DATA_LEN-1:0] mem18,
+   output wire [`DATA_LEN-1:0] mem19,
+   output wire [`DATA_LEN-1:0] mem20,
+   output wire [`DATA_LEN-1:0] mem21,
+   output wire [`DATA_LEN-1:0] mem22,
+   output wire [`DATA_LEN-1:0] mem23,
+   output wire [`DATA_LEN-1:0] mem24,
+   output wire [`DATA_LEN-1:0] mem25,
+   output wire [`DATA_LEN-1:0] mem26,
+   output wire [`DATA_LEN-1:0] mem27,
+   output wire [`DATA_LEN-1:0] mem28,
+   output wire [`DATA_LEN-1:0] mem29,
+   output wire [`DATA_LEN-1:0] mem30,
+   output wire [`DATA_LEN-1:0] mem31
+   );
+
+   // Set priority on instruction2 WriteBack
+   // wrrfent = comtag
+   wire [`RRF_SEL-1:0] 		 comreg1_tag;
+   wire [`RRF_SEL-1:0] 		 comreg2_tag;
+   wire 			 clearbusy1 = we1;
+   wire 			 clearbusy2 = we2;
+
+   // EDIT mutation: GPR0 can be assigned 
+    wire 			 we1_0reg = we1 && (wreg1 != `REG_SEL'b0);
+   
+    wire 			 we2_0reg = we2 && (wreg2 != `REG_SEL'b0);
+
+    // wire 			 we1_0reg = we1;
+   
+    // wire 			 we2_0reg = we2;
+   
+   // END EDIT
+
+   wire 			 we1_prior2 = ((wreg1 == wreg2) &&
+					       we1_0reg && we2_0reg) ? 
+				 1'b0 : we1_0reg;
+   
+   // Set priority on instruction2 WriteBack
+   // we when wrrfent1 == comreg1_tag
+   ram_sync_nolatch_4r2w
+     #(`REG_SEL, `DATA_LEN, `REG_NUM)
+   regfile(
+	   .clk(clk),
+	   .raddr1(rs1_1),
+	   .raddr2(rs2_1),
+	   .raddr3(rs1_2),
+	   .raddr4(rs2_2),
+	   .rdata1(rs1_1data),
+	   .rdata2(rs2_1data),
+	   .rdata3(rs1_2data),
+	   .rdata4(rs2_2data),
+	   .waddr1(wreg1),
+	   .waddr2(wreg2),
+	   .wdata1(wdata1),
+	   .wdata2(wdata2),
+	   //	   .we1(we1_prior2),
+	   .we1(we1_0reg),
+	   .we2(we2_0reg),
+	   .mem0(mem0),
+	   .mem1(mem1),
+	   .mem2(mem2),
+	   .mem3(mem3),
+	   .mem4(mem4),
+	   .mem5(mem5),
+	   .mem6(mem6),
+	   .mem7(mem7),
+	   .mem8(mem8),
+	   .mem9(mem9),
+	   .mem10(mem10),
+	   .mem11(mem11),
+	   .mem12(mem12),
+	   .mem13(mem13),
+	   .mem14(mem14),
+	   .mem15(mem15),
+	   .mem16(mem16),
+	   .mem17(mem17),
+	   .mem18(mem18),
+	   .mem19(mem19),
+	   .mem20(mem20),
+	   .mem21(mem21),
+	   .mem22(mem22),
+	   .mem23(mem23),
+	   .mem24(mem24),
+	   .mem25(mem25),
+	   .mem26(mem26),
+	   .mem27(mem27),
+	   .mem28(mem28),
+	   .mem29(mem29),
+	   .mem30(mem30),
+	   .mem31(mem31)
+	   );
+
+   
+   renaming_table rt(
+		     .clk(clk),
+		     .reset(reset),
+		     .rs1_1(rs1_1),
+		     .rs2_1(rs2_1),
+		     .rs1_2(rs1_2),
+		     .rs2_2(rs2_2),
+		     .comreg1(wreg1),
+		     .comreg2(wreg2),
+		     .rs1_1tag(rs1_1tag),
+		     .rs2_1tag(rs2_1tag),
+		     .rs1_2tag(rs1_2tag),
+		     .rs2_2tag(rs2_2tag),
+		     .rs1_1busy(rs1_1busy),
+		     .rs2_1busy(rs2_1busy),
+		     .rs1_2busy(rs1_2busy),
+		     .rs2_2busy(rs2_2busy),
+		     // EDIT mutation: Register redirection in the renaming table 
+		     .settagbusy1_addr(tagbusy1_addr),
+			 //.settagbusy1_addr(tagbusy2_addr),
+			 // END EDIT
+		     .settagbusy2_addr(tagbusy2_addr),
+		     .settagbusy1(tagbusy1_we),
+		     .settagbusy2(tagbusy2_we),
+		     .settag1(settag1),
+		     .settag2(settag2),
+		     .setbusy1_spectag(tagbusy1_spectag),
+		     .setbusy2_spectag(tagbusy2_spectag),
+		     .clearbusy1(clearbusy1),
+		     .clearbusy2(clearbusy2),
+		     .wrrfent1(wrrfent1),
+		     .wrrfent2(wrrfent2),
+		     .prmiss(prmiss),
+		     .prsuccess(prsuccess),
+		     .prtag(prtag),
+		     .mpft_valid1(mpft_valid1),
+		     .mpft_valid2(mpft_valid2)
+		     );
+   
+
+endmodule // arf
+
+// Set priority on instruction2 WriteBack
+/*
+ clear busy when comtag = rt_tag[comreg]
+ */
+
+module select_vector(
+		     input wire [`SPECTAG_LEN-1:0] spectag,
+		     input wire [`REG_NUM-1:0] 	   dat0,
+		     input wire [`REG_NUM-1:0] 	   dat1,
+		     input wire [`REG_NUM-1:0] 	   dat2,
+		     input wire [`REG_NUM-1:0] 	   dat3,
+		     input wire [`REG_NUM-1:0] 	   dat4,
+		     output reg [`REG_NUM-1:0] 	   out
+		     );
+
+   always @ (*) begin
+      out = 0;
+      case (spectag)
+	5'b00001 : out = dat1;
+	5'b00010 : out = dat2;
+	5'b00100 : out = dat3;
+	5'b01000 : out = dat4;
+	5'b10000 : out = dat0;
+	default : out = 0;
+      endcase // case (spectag) 
+   end
+endmodule // select_vector
+
+module renaming_table
+  (
+   input wire 			 clk,
+   input wire 			 reset,
+   input wire [`REG_SEL-1:0] 	 rs1_1,
+   input wire [`REG_SEL-1:0] 	 rs2_1,
+   input wire [`REG_SEL-1:0] 	 rs1_2,
+   input wire [`REG_SEL-1:0] 	 rs2_2,
+   input wire [`REG_SEL-1:0] 	 comreg1, //clearbusy1addr
+   input wire [`REG_SEL-1:0] 	 comreg2, //clearbusy2addr
+   input wire 			 clearbusy1, //calc on arf
+   input wire 			 clearbusy2,
+   input wire [`RRF_SEL-1:0] 	 wrrfent1,
+   input wire [`RRF_SEL-1:0] 	 wrrfent2, 
+   output wire [`RRF_SEL-1:0] 	 rs1_1tag,
+   output wire [`RRF_SEL-1:0] 	 rs2_1tag,
+   output wire [`RRF_SEL-1:0] 	 rs1_2tag,
+   output wire [`RRF_SEL-1:0] 	 rs2_2tag,
+   output wire 			 rs1_1busy,
+   output wire 			 rs2_1busy,
+   output wire 			 rs1_2busy,
+   output wire 			 rs2_2busy,
+   input wire [`REG_SEL-1:0] 	 settagbusy1_addr,
+   input wire [`REG_SEL-1:0] 	 settagbusy2_addr,
+   input wire 			 settagbusy1,
+   input wire 			 settagbusy2,
+   input wire [`RRF_SEL-1:0] 	 settag1,
+   input wire [`RRF_SEL-1:0] 	 settag2,
+   input wire [`SPECTAG_LEN-1:0] setbusy1_spectag,
+   input wire [`SPECTAG_LEN-1:0] setbusy2_spectag,
+
+   input wire 			 prmiss,
+   input wire 			 prsuccess,
+   input wire [`SPECTAG_LEN-1:0] prtag,
+   input wire [`SPECTAG_LEN-1:0] mpft_valid1,
+   input wire [`SPECTAG_LEN-1:0] mpft_valid2
+   );
+   
+   reg [`REG_NUM-1:0] 		 busy_0;
+   reg [`REG_NUM-1:0] 		 tag0_0;
+   reg [`REG_NUM-1:0] 		 tag1_0;
+   reg [`REG_NUM-1:0] 		 tag2_0;
+   reg [`REG_NUM-1:0] 		 tag3_0;
+   reg [`REG_NUM-1:0] 		 tag4_0;
+   reg [`REG_NUM-1:0] 		 tag5_0;
+   
+   reg [`REG_NUM-1:0] 		 busy_1;
+   reg [`REG_NUM-1:0] 		 tag0_1;
+   reg [`REG_NUM-1:0] 		 tag1_1;
+   reg [`REG_NUM-1:0] 		 tag2_1;
+   reg [`REG_NUM-1:0] 		 tag3_1;
+   reg [`REG_NUM-1:0] 		 tag4_1;
+   reg [`REG_NUM-1:0] 		 tag5_1;
+   
+   reg [`REG_NUM-1:0] 		 busy_2;
+   reg [`REG_NUM-1:0] 		 tag0_2;
+   reg [`REG_NUM-1:0] 		 tag1_2;
+   reg [`REG_NUM-1:0] 		 tag2_2;
+   reg [`REG_NUM-1:0] 		 tag3_2;
+   reg [`REG_NUM-1:0] 		 tag4_2;
+   reg [`REG_NUM-1:0] 		 tag5_2;
+   
+   reg [`REG_NUM-1:0] 		 busy_3;
+   reg [`REG_NUM-1:0] 		 tag0_3;
+   reg [`REG_NUM-1:0] 		 tag1_3;
+   reg [`REG_NUM-1:0] 		 tag2_3;
+   reg [`REG_NUM-1:0] 		 tag3_3;
+   reg [`REG_NUM-1:0] 		 tag4_3;
+   reg [`REG_NUM-1:0] 		 tag5_3;
+   
+   reg [`REG_NUM-1:0] 		 busy_4;
+   reg [`REG_NUM-1:0] 		 tag0_4;
+   reg [`REG_NUM-1:0] 		 tag1_4;
+   reg [`REG_NUM-1:0] 		 tag2_4;
+   reg [`REG_NUM-1:0] 		 tag3_4;
+   reg [`REG_NUM-1:0] 		 tag4_4;
+   reg [`REG_NUM-1:0] 		 tag5_4;
+   
+   reg [`REG_NUM-1:0] 		 busy_master;
+   reg [`REG_NUM-1:0] 		 tag0_master;
+   reg [`REG_NUM-1:0] 		 tag1_master;
+   reg [`REG_NUM-1:0] 		 tag2_master;
+   reg [`REG_NUM-1:0] 		 tag3_master;
+   reg [`REG_NUM-1:0] 		 tag4_master;
+   reg [`REG_NUM-1:0] 		 tag5_master;
+
+   wire [`REG_NUM-1:0] 		 tag0;
+   wire [`REG_NUM-1:0] 		 tag1;
+   wire [`REG_NUM-1:0] 		 tag2;
+   wire [`REG_NUM-1:0] 		 tag3;
+   wire [`REG_NUM-1:0] 		 tag4;
+   wire [`REG_NUM-1:0] 		 tag5;
+
+   wire [`SPECTAG_LEN-1:0] 	 wesetvec1 = ~mpft_valid1;
+   wire [`SPECTAG_LEN-1:0] 	 wesetvec2 = ~mpft_valid2;
+   
+   wire 			 settagbusy1_prior2 = settagbusy1 && settagbusy2 && 
+				 (settagbusy1_addr == settagbusy2_addr) ? 1'b0 : settagbusy1;
+
+   wire 			 clearbusy1_priorset = clearbusy1 && 
+				 ~(
+				   (settagbusy1 && (settagbusy1_addr == comreg1)) ||
+				   (settagbusy2 && (settagbusy2_addr == comreg1))
+				   );
+   
+   wire 			 clearbusy2_priorset = clearbusy2 &&
+				 ~(
+				   (settagbusy1 && (settagbusy1_addr == comreg2)) ||
+				   (settagbusy2 && (settagbusy2_addr == comreg2))
+				   );
+
+   wire 			 setbusy1_master = settagbusy1_prior2;
+   
+   wire 			 setbusy2_master = settagbusy2;
+
+   wire 			 clearbusy1_master = clearbusy1 &&  
+				 (wrrfent1 == {tag5_master[comreg1], tag4_master[comreg1],
+					       tag3_master[comreg1], tag2_master[comreg1], 
+					       tag1_master[comreg1], tag0_master[comreg1]}) &&
+				 ~((setbusy1_master && (settagbusy1_addr == comreg1)) ||
+				   (setbusy2_master && (settagbusy2_addr == comreg1)));
+
+   wire 			 clearbusy2_master = clearbusy2 &&  
+				 (wrrfent2 == {tag5_master[comreg2], tag4_master[comreg2], 
+					       tag3_master[comreg2], tag2_master[comreg2], 
+					       tag1_master[comreg2], tag0_master[comreg2]}) &&
+				 ~((setbusy1_master && (settagbusy1_addr == comreg2)) ||
+				   (setbusy2_master && (settagbusy2_addr == comreg2)));
+
+   
+   wire 			 setbusy1_0 = settagbusy1_prior2 && wesetvec1[0];
+   
+   wire 			 setbusy2_0 = settagbusy2 && wesetvec2[0];
+
+   wire 			 clearbusy1_0 = clearbusy1 &&  
+				 (wrrfent1 == 
+				  {tag5_0[comreg1], tag4_0[comreg1], tag3_0[comreg1],
+				   tag2_0[comreg1], tag1_0[comreg1], tag0_0[comreg1]}) &&
+				 ~((setbusy1_0 && (settagbusy1_addr == comreg1)) ||
+				   (setbusy2_0 && (settagbusy2_addr == comreg1)));
+
+   wire 			 clearbusy2_0 = clearbusy2 &&  
+				 (wrrfent2 == 
+				  {tag5_0[comreg2], tag4_0[comreg2], tag3_0[comreg2],
+				   tag2_0[comreg2], tag1_0[comreg2], tag0_0[comreg2]}) &&
+				 ~((setbusy1_0 && (settagbusy1_addr == comreg2)) ||
+				   (setbusy2_0 && (settagbusy2_addr == comreg2)));
+
+   wire 			 setbusy1_1 = settagbusy1_prior2 && wesetvec1[1];
+   
+   wire 			 setbusy2_1 = settagbusy2 && wesetvec2[1];
+
+   wire 			 clearbusy1_1 = clearbusy1 &&  
+				 (wrrfent1 == 
+				  {tag5_1[comreg1], tag4_1[comreg1], tag3_1[comreg1],
+				   tag2_1[comreg1], tag1_1[comreg1], tag0_1[comreg1]}) &&
+				 ~((setbusy1_1 && (settagbusy1_addr == comreg1)) ||
+				   (setbusy2_1 && (settagbusy2_addr == comreg1)));
+
+   wire 			 clearbusy2_1 = clearbusy2 &&  
+				 (wrrfent2 == 
+				  {tag5_1[comreg2], tag4_1[comreg2], tag3_1[comreg2],
+				   tag2_1[comreg2], tag1_1[comreg2], tag0_1[comreg2]}) &&
+				 ~((setbusy1_1 && (settagbusy1_addr == comreg2)) ||
+				   (setbusy2_1 && (settagbusy2_addr == comreg2)));
+
+   wire 			 setbusy1_2 = settagbusy1_prior2 && wesetvec1[2];
+   
+   wire 			 setbusy2_2 = settagbusy2 && wesetvec2[2];
+
+   wire 			 clearbusy1_2 = clearbusy1 &&  
+				 (wrrfent1 == 
+				  {tag5_2[comreg1], tag4_2[comreg1], tag3_2[comreg1],
+				   tag2_2[comreg1], tag1_2[comreg1], tag0_2[comreg1]}) &&
+				 ~((setbusy1_2 && (settagbusy1_addr == comreg1)) ||
+				   (setbusy2_2 && (settagbusy2_addr == comreg1)));
+
+   wire 			 clearbusy2_2 = clearbusy2 &&  
+				 (wrrfent2 == 
+				  {tag5_2[comreg2], tag4_2[comreg2], tag3_2[comreg2],
+				   tag2_2[comreg2], tag1_2[comreg2], tag0_2[comreg2]}) &&
+				 ~((setbusy1_2 && (settagbusy1_addr == comreg2)) ||
+				   (setbusy2_2 && (settagbusy2_addr == comreg2)));
+
+   wire 			 setbusy1_3 = settagbusy1_prior2 && wesetvec1[3];
+   
+   wire 			 setbusy2_3 = settagbusy2 && wesetvec2[3];
+
+   wire 			 clearbusy1_3 = clearbusy1 &&  
+				 (wrrfent1 == 
+				  {tag5_3[comreg1], tag4_3[comreg1], tag3_3[comreg1],
+				   tag2_3[comreg1], tag1_3[comreg1], tag0_3[comreg1]}) &&
+				 ~((setbusy1_3 && (settagbusy1_addr == comreg1)) ||
+				   (setbusy2_3 && (settagbusy2_addr == comreg1)));
+
+   wire 			 clearbusy2_3 = clearbusy2 &&  
+				 (wrrfent2 == 
+				  {tag5_3[comreg2], tag4_3[comreg2], tag3_3[comreg2],
+				   tag2_3[comreg2], tag1_3[comreg2], tag0_3[comreg2]}) &&
+				 ~((setbusy1_3 && (settagbusy1_addr == comreg2)) ||
+				   (setbusy2_3 && (settagbusy2_addr == comreg2)));
+
+   wire 			 setbusy1_4 = settagbusy1_prior2 && wesetvec1[4];
+   
+   wire 			 setbusy2_4 = settagbusy2 && wesetvec2[4];
+
+   wire 			 clearbusy1_4 = clearbusy1 &&  
+				 (wrrfent1 == 
+				  {tag5_4[comreg1], tag4_4[comreg1], tag3_4[comreg1],
+				   tag2_4[comreg1], tag1_4[comreg1], tag0_4[comreg1]}) &&
+				 ~((setbusy1_4 && (settagbusy1_addr == comreg1)) ||
+				   (setbusy2_4 && (settagbusy2_addr == comreg1)));
+
+   wire 			 clearbusy2_4 = clearbusy2 &&  
+				 (wrrfent2 == 
+				  {tag5_4[comreg2], tag4_4[comreg2], tag3_4[comreg2],
+				   tag2_4[comreg2], tag1_4[comreg2], tag0_4[comreg2]}) &&
+				 ~((setbusy1_4 && (settagbusy1_addr == comreg2)) ||
+				   (setbusy2_4 && (settagbusy2_addr == comreg2)));
+
+   wire [`REG_NUM-1:0] 		 next_bsymas = 
+				 (busy_master &
+				  ((clearbusy1_master) ? 
+				   ~(`REG_NUM'b1 << comreg1) : 
+				   ~(`REG_NUM'b0)) &
+				  ((clearbusy2_master) ? 
+				   ~(`REG_NUM'b1 << comreg2) : 
+				   ~(`REG_NUM'b0))
+				  );
+
+   wire [`REG_NUM-1:0] 		 next_bsyand_0 =
+				 ((clearbusy1_0) ? 
+				  ~(`REG_NUM'b1 << comreg1) : 
+				  ~(`REG_NUM'b0)) &
+				 ((clearbusy2_0) ? 
+				  ~(`REG_NUM'b1 << comreg2) : 
+				  ~(`REG_NUM'b0));
+
+   wire [`REG_NUM-1:0] 		 next_bsyand_1 =
+				 ((clearbusy1_1) ? 
+				  ~(`REG_NUM'b1 << comreg1) : 
+				  ~(`REG_NUM'b0)) &
+				 ((clearbusy2_1) ? 
+				  ~(`REG_NUM'b1 << comreg2) : 
+				  ~(`REG_NUM'b0));
+
+   wire [`REG_NUM-1:0] 		 next_bsyand_2 =
+				 ((clearbusy1_2) ? 
+				  ~(`REG_NUM'b1 << comreg1) : 
+				  ~(`REG_NUM'b0)) &
+				 ((clearbusy2_2) ? 
+				  ~(`REG_NUM'b1 << comreg2) : 
+				  ~(`REG_NUM'b0));
+
+   wire [`REG_NUM-1:0] 		 next_bsyand_3 =
+				 ((clearbusy1_3) ? 
+				  ~(`REG_NUM'b1 << comreg1) : 
+				  ~(`REG_NUM'b0)) &
+				 ((clearbusy2_3) ? 
+				  ~(`REG_NUM'b1 << comreg2) : 
+				  ~(`REG_NUM'b0));
+
+   wire [`REG_NUM-1:0] 		 next_bsyand_4 =
+				 ((clearbusy1_4) ? 
+				  ~(`REG_NUM'b1 << comreg1) : 
+				  ~(`REG_NUM'b0)) &
+				 ((clearbusy2_4) ? 
+				  ~(`REG_NUM'b1 << comreg2) : 
+				  ~(`REG_NUM'b0));
+   
+   
+   assign rs1_1busy = busy_master[rs1_1];
+   assign rs2_1busy = busy_master[rs2_1];
+   assign rs1_2busy = busy_master[rs1_2];
+   assign rs2_2busy = busy_master[rs2_2];
+
+   assign rs1_1tag = {tag5_master[rs1_1], tag4_master[rs1_1], tag3_master[rs1_1],
+		      tag2_master[rs1_1], tag1_master[rs1_1], tag0_master[rs1_1]};
+   assign rs2_1tag = {tag5_master[rs2_1], tag4_master[rs2_1], tag3_master[rs2_1],
+		      tag2_master[rs2_1], tag1_master[rs2_1], tag0_master[rs2_1]};
+   assign rs1_2tag = {tag5_master[rs1_2], tag4_master[rs1_2], tag3_master[rs1_2],
+		      tag2_master[rs1_2], tag1_master[rs1_2], tag0_master[rs1_2]};
+   assign rs2_2tag = {tag5_master[rs2_2], tag4_master[rs2_2], tag3_master[rs2_2],
+		      tag2_master[rs2_2], tag1_master[rs2_2], tag0_master[rs2_2]};
+
+
+   
+   always @ (posedge clk) begin
+      if (reset) begin
+	 busy_0 <= 0;
+	 busy_1 <= 0;
+	 busy_2 <= 0;
+	 busy_3 <= 0;
+	 busy_4 <= 0;
+	 busy_master <= 0;
+      end else begin
+	 if (prsuccess) begin
+	    busy_master <= next_bsymas;
+	    busy_1 <= (prtag == 5'b00010) ? next_bsymas : (next_bsyand_1 & busy_1);
+	    busy_2 <= (prtag == 5'b00100) ? next_bsymas : (next_bsyand_2 & busy_2);
+	    busy_3 <= (prtag == 5'b01000) ? next_bsymas : (next_bsyand_3 & busy_3);
+	    busy_4 <= (prtag == 5'b10000) ? next_bsymas : (next_bsyand_4 & busy_4);
+	    busy_0 <= (prtag == 5'b00001) ? next_bsymas : (next_bsyand_0 & busy_0);	    
+	 end else if (prmiss) begin // if (prsuccess)
+	    if (prtag == 5'b00010) begin
+	       busy_0 <= busy_1;
+	       busy_1 <= busy_1;
+	       busy_2 <= busy_1;
+	       busy_3 <= busy_1;
+	       busy_4 <= busy_1;
+	       busy_master <= busy_1;
+	    end else if (prtag == 5'b00100) begin
+	       busy_0 <= busy_2;
+	       busy_1 <= busy_2;
+	       busy_2 <= busy_2;
+	       busy_3 <= busy_2;
+	       busy_4 <= busy_2;
+	       busy_master <= busy_2;
+	    end else if (prtag == 5'b01000) begin
+	       busy_0 <= busy_3;
+	       busy_1 <= busy_3;
+	       busy_2 <= busy_3;
+	       busy_3 <= busy_3;
+	       busy_4 <= busy_3;
+	       busy_master <= busy_3;
+	    end else if (prtag == 5'b10000) begin
+	       busy_0 <= busy_4;
+	       busy_1 <= busy_4;
+	       busy_2 <= busy_4;
+	       busy_3 <= busy_4;
+	       busy_4 <= busy_4;
+	       busy_master <= busy_4;
+	    end else if (prtag == 5'b00001) begin
+	       busy_0 <= busy_0;
+	       busy_1 <= busy_0;
+	       busy_2 <= busy_0;
+	       busy_3 <= busy_0;
+	       busy_4 <= busy_0;
+	       busy_master <= busy_0;
+	    end
+	 end else begin // if (prmiss)
+	    /*
+	     if (setbusy1_j)
+	     busy_j[settagbusy1_addr] <= 1'b1;
+	     if (setbusy2_j)
+	     busy_j[settagbusy2_addr] <= 1'b1;
+	     if (clearbusy1_j)
+	     busy_j[comreg1] <= 1'b0;
+	     if (clearbusy2_j)
+	     busy_j[comreg2] <= 1'b0;
+	     */
+	    if (setbusy1_master)
+	      busy_master[settagbusy1_addr] <= 1'b1;
+	    if (setbusy2_master)
+	      busy_master[settagbusy2_addr] <= 1'b1;
+	    if (clearbusy1_master)
+	      busy_master[comreg1] <= 1'b0;
+	    if (clearbusy2_master)
+	      busy_master[comreg2] <= 1'b0;
+
+	    if (setbusy1_0)
+	      busy_0[settagbusy1_addr] <= 1'b1;
+	    if (setbusy2_0)
+	      busy_0[settagbusy2_addr] <= 1'b1;
+	    if (clearbusy1_0)
+	      busy_0[comreg1] <= 1'b0;
+	    if (clearbusy2_0)
+	      busy_0[comreg2] <= 1'b0;
+
+	    if (setbusy1_1)
+	      busy_1[settagbusy1_addr] <= 1'b1;
+	    if (setbusy2_1)
+	      busy_1[settagbusy2_addr] <= 1'b1;
+	    if (clearbusy1_1)
+	      busy_1[comreg1] <= 1'b0;
+	    if (clearbusy2_1)
+	      busy_1[comreg2] <= 1'b0;
+
+	    if (setbusy1_2)
+	      busy_2[settagbusy1_addr] <= 1'b1;
+	    if (setbusy2_2)
+	      busy_2[settagbusy2_addr] <= 1'b1;
+	    if (clearbusy1_2)
+	      busy_2[comreg1] <= 1'b0;
+	    if (clearbusy2_2)
+	      busy_2[comreg2] <= 1'b0;
+
+	    if (setbusy1_3)
+	      busy_3[settagbusy1_addr] <= 1'b1;
+	    if (setbusy2_3)
+	      busy_3[settagbusy2_addr] <= 1'b1;
+	    if (clearbusy1_3)
+	      busy_3[comreg1] <= 1'b0;
+	    if (clearbusy2_3)
+	      busy_3[comreg2] <= 1'b0;
+
+	    if (setbusy1_4)
+	      busy_4[settagbusy1_addr] <= 1'b1;
+	    if (setbusy2_4)
+	      busy_4[settagbusy2_addr] <= 1'b1;
+	    if (clearbusy1_4)
+	      busy_4[comreg1] <= 1'b0;
+	    if (clearbusy2_4)
+	      busy_4[comreg2] <= 1'b0;
+
+	 end // else: !if(prmiss)
+      end // else: !if(reset)
+   end // always @ (posedge clk)
+
+   always @ (posedge clk) begin
+      if (reset) begin
+	 tag0_0 <= 0;
+	 tag1_0 <= 0;
+	 tag2_0 <= 0;
+	 tag3_0 <= 0;
+	 tag4_0 <= 0;
+	 tag5_0 <= 0;
+	 tag0_1 <= 0;
+	 tag1_1 <= 0;
+	 tag2_1 <= 0;
+	 tag3_1 <= 0;
+	 tag4_1 <= 0;
+	 tag5_1 <= 0;
+	 tag0_2 <= 0;
+	 tag1_2 <= 0;
+	 tag2_2 <= 0;
+	 tag3_2 <= 0;
+	 tag4_2 <= 0;
+	 tag5_2 <= 0;
+	 tag0_3 <= 0;
+	 tag1_3 <= 0;
+	 tag2_3 <= 0;
+	 tag3_3 <= 0;
+	 tag4_3 <= 0;
+	 tag5_3 <= 0;
+	 tag0_4 <= 0;
+	 tag1_4 <= 0;
+	 tag2_4 <= 0;
+	 tag3_4 <= 0;
+	 tag4_4 <= 0;
+	 tag5_4 <= 0;
+	 tag0_master <= 0;
+	 tag1_master <= 0;
+	 tag2_master <= 0;
+	 tag3_master <= 0;
+	 tag4_master <= 0;
+	 tag5_master <= 0;
+      end else if (prsuccess) begin
+	 tag0_master <= tag0_master;
+	 tag1_master <= tag1_master;
+	 tag2_master <= tag2_master;
+	 tag3_master <= tag3_master;
+	 tag4_master <= tag4_master;	 
+	 tag5_master <= tag5_master;
+	 
+	 if (prtag == 5'b00010) begin
+	    tag0_1 <= tag0_master;
+	    tag1_1 <= tag1_master;
+	    tag2_1 <= tag2_master;
+	    tag3_1 <= tag3_master;
+	    tag4_1 <= tag4_master;
+	    tag5_1 <= tag5_master;
+	 end else if (prtag == 5'b00100) begin
+	    tag0_2 <= tag0_master;
+	    tag1_2 <= tag1_master;
+	    tag2_2 <= tag2_master;
+	    tag3_2 <= tag3_master;
+	    tag4_2 <= tag4_master;
+	    tag5_2 <= tag5_master;
+	 end else if (prtag == 5'b01000) begin
+	    tag0_3 <= tag0_master;
+	    tag1_3 <= tag1_master;
+	    tag2_3 <= tag2_master;
+	    tag3_3 <= tag3_master;
+	    tag4_3 <= tag4_master;
+	    tag5_3 <= tag5_master;
+	 end else if (prtag == 5'b10000) begin
+	    tag0_4 <= tag0_master;
+	    tag1_4 <= tag1_master;
+	    tag2_4 <= tag2_master;
+	    tag3_4 <= tag3_master;
+	    tag4_4 <= tag4_master;
+	    tag5_4 <= tag5_master;
+	 end else if (prtag == 5'b00001) begin
+	    tag0_0 <= tag0_master;
+	    tag1_0 <= tag1_master;
+	    tag2_0 <= tag2_master;
+	    tag3_0 <= tag3_master;
+	    tag4_0 <= tag4_master;
+	    tag5_0 <= tag5_master;
+	 end
+      end else if (prmiss) begin // if (prsuccess)
+	 if (prtag == 5'b00010) begin
+	    tag0_0 <= tag0_1;
+	    tag1_0 <= tag1_1;
+	    tag2_0 <= tag2_1;
+	    tag3_0 <= tag3_1;
+	    tag4_0 <= tag4_1;
+	    tag5_0 <= tag5_1;
+	    tag0_1 <= tag0_1;
+	    tag1_1 <= tag1_1;
+	    tag2_1 <= tag2_1;
+	    tag3_1 <= tag3_1;
+	    tag4_1 <= tag4_1;
+	    tag5_1 <= tag5_1;
+	    tag0_2 <= tag0_1;
+	    tag1_2 <= tag1_1;
+	    tag2_2 <= tag2_1;
+	    tag3_2 <= tag3_1;
+	    tag4_2 <= tag4_1;
+	    tag5_2 <= tag5_1;
+	    tag0_3 <= tag0_1;
+	    tag1_3 <= tag1_1;
+	    tag2_3 <= tag2_1;
+	    tag3_3 <= tag3_1;
+	    tag4_3 <= tag4_1;
+	    tag5_3 <= tag5_1;
+	    tag0_4 <= tag0_1;
+	    tag1_4 <= tag1_1;
+	    tag2_4 <= tag2_1;
+	    tag3_4 <= tag3_1;
+	    tag4_4 <= tag4_1;
+	    tag5_4 <= tag5_1;
+	    tag0_master <= tag0_1;
+	    tag1_master <= tag1_1;
+	    tag2_master <= tag2_1;
+	    tag3_master <= tag3_1;
+	    tag4_master <= tag4_1;
+	    tag5_master <= tag5_1;
+	 end else if (prtag == 5'b00100) begin
+	    tag0_0 <= tag0_2;
+	    tag1_0 <= tag1_2;
+	    tag2_0 <= tag2_2;
+	    tag3_0 <= tag3_2;
+	    tag4_0 <= tag4_2;
+	    tag5_0 <= tag5_2;
+	    tag0_1 <= tag0_2;
+	    tag1_1 <= tag1_2;
+	    tag2_1 <= tag2_2;
+	    tag3_1 <= tag3_2;
+	    tag4_1 <= tag4_2;
+	    tag5_1 <= tag5_2;
+	    tag0_2 <= tag0_2;
+	    tag1_2 <= tag1_2;
+	    tag2_2 <= tag2_2;
+	    tag3_2 <= tag3_2;
+	    tag4_2 <= tag4_2;
+	    tag5_2 <= tag5_2;
+	    tag0_3 <= tag0_2;
+	    tag1_3 <= tag1_2;
+	    tag2_3 <= tag2_2;
+	    tag3_3 <= tag3_2;
+	    tag4_3 <= tag4_2;
+	    tag5_3 <= tag5_2;
+	    tag0_4 <= tag0_2;
+	    tag1_4 <= tag1_2;
+	    tag2_4 <= tag2_2;
+	    tag3_4 <= tag3_2;
+	    tag4_4 <= tag4_2;
+	    tag5_4 <= tag5_2;
+	    tag0_master <= tag0_2;
+	    tag1_master <= tag1_2;
+	    tag2_master <= tag2_2;
+	    tag3_master <= tag3_2;
+	    tag4_master <= tag4_2;
+	    tag5_master <= tag5_2;
+	 end else if (prtag == 5'b01000) begin
+	    tag0_0 <= tag0_3;
+	    tag1_0 <= tag1_3;
+	    tag2_0 <= tag2_3;
+	    tag3_0 <= tag3_3;
+	    tag4_0 <= tag4_3;
+	    tag5_0 <= tag5_3;
+	    tag0_1 <= tag0_3;
+	    tag1_1 <= tag1_3;
+	    tag2_1 <= tag2_3;
+	    tag3_1 <= tag3_3;
+	    tag4_1 <= tag4_3;
+	    tag5_1 <= tag5_3;
+	    tag0_2 <= tag0_3;
+	    tag1_2 <= tag1_3;
+	    tag2_2 <= tag2_3;
+	    tag3_2 <= tag3_3;
+	    tag4_2 <= tag4_3;
+	    tag5_2 <= tag5_3;
+	    tag0_3 <= tag0_3;
+	    tag1_3 <= tag1_3;
+	    tag2_3 <= tag2_3;
+	    tag3_3 <= tag3_3;
+	    tag4_3 <= tag4_3;
+	    tag5_3 <= tag5_3;
+	    tag0_4 <= tag0_3;
+	    tag1_4 <= tag1_3;
+	    tag2_4 <= tag2_3;
+	    tag3_4 <= tag3_3;
+	    tag4_4 <= tag4_3;
+	    tag5_4 <= tag5_3;
+	    tag0_master <= tag0_3;
+	    tag1_master <= tag1_3;
+	    tag2_master <= tag2_3;
+	    tag3_master <= tag3_3;
+	    tag4_master <= tag4_3;
+	    tag5_master <= tag5_3;
+	 end else if (prtag == 5'b10000) begin
+	    tag0_0 <= tag0_4;
+	    tag1_0 <= tag1_4;
+	    tag2_0 <= tag2_4;
+	    tag3_0 <= tag3_4;
+	    tag4_0 <= tag4_4;
+	    tag5_0 <= tag5_4;
+	    tag0_1 <= tag0_4;
+	    tag1_1 <= tag1_4;
+	    tag2_1 <= tag2_4;
+	    tag3_1 <= tag3_4;
+	    tag4_1 <= tag4_4;
+	    tag5_1 <= tag5_4;
+	    tag0_2 <= tag0_4;
+	    tag1_2 <= tag1_4;
+	    tag2_2 <= tag2_4;
+	    tag3_2 <= tag3_4;
+	    tag4_2 <= tag4_4;
+	    tag5_2 <= tag5_4;
+	    tag0_3 <= tag0_4;
+	    tag1_3 <= tag1_4;
+	    tag2_3 <= tag2_4;
+	    tag3_3 <= tag3_4;
+	    tag4_3 <= tag4_4;
+	    tag5_3 <= tag5_4;
+	    tag0_4 <= tag0_4;
+	    tag1_4 <= tag1_4;
+	    tag2_4 <= tag2_4;
+	    tag3_4 <= tag3_4;
+	    tag4_4 <= tag4_4;
+	    tag5_4 <= tag5_4;
+	    tag0_master <= tag0_4;
+	    tag1_master <= tag1_4;
+	    tag2_master <= tag2_4;
+	    tag3_master <= tag3_4;
+	    tag4_master <= tag4_4;
+	    tag5_master <= tag5_4;
+	 end else if (prtag == 5'b00001) begin
+	    tag0_0 <= tag0_0;
+	    tag1_0 <= tag1_0;
+	    tag2_0 <= tag2_0;
+	    tag3_0 <= tag3_0;
+	    tag4_0 <= tag4_0;
+	    tag5_0 <= tag5_0;
+	    tag0_1 <= tag0_0;
+	    tag1_1 <= tag1_0;
+	    tag2_1 <= tag2_0;
+	    tag3_1 <= tag3_0;
+	    tag4_1 <= tag4_0;
+	    tag5_1 <= tag5_0;
+	    tag0_2 <= tag0_0;
+	    tag1_2 <= tag1_0;
+	    tag2_2 <= tag2_0;
+	    tag3_2 <= tag3_0;
+	    tag4_2 <= tag4_0;
+	    tag5_2 <= tag5_0;
+	    tag0_3 <= tag0_0;
+	    tag1_3 <= tag1_0;
+	    tag2_3 <= tag2_0;
+	    tag3_3 <= tag3_0;
+	    tag4_3 <= tag4_0;
+	    tag5_3 <= tag5_0;
+	    tag0_4 <= tag0_0;
+	    tag1_4 <= tag1_0;
+	    tag2_4 <= tag2_0;
+	    tag3_4 <= tag3_0;
+	    tag4_4 <= tag4_0;
+	    tag5_4 <= tag5_0;
+	    tag0_master <= tag0_0;
+	    tag1_master <= tag1_0;
+	    tag2_master <= tag2_0;
+	    tag3_master <= tag3_0;
+	    tag4_master <= tag4_0;
+	    tag5_master <= tag5_0;
+	 end 
+      end else begin // if (prmiss)
+	 if (settagbusy1) begin
+	    //TAG0
+	    tag0_master[settagbusy1_addr] <= settagbusy1_prior2 ?
+					     settag1[0] : tag0_master[settagbusy1_addr];
+	    
+	    tag0_0[settagbusy1_addr] <= (wesetvec1[0] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[0] : tag0_0[settagbusy1_addr];
+	    tag0_1[settagbusy1_addr] <= (wesetvec1[1] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[0] : tag0_1[settagbusy1_addr];
+	    tag0_2[settagbusy1_addr] <= (wesetvec1[2] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[0] : tag0_2[settagbusy1_addr];
+	    tag0_3[settagbusy1_addr] <= (wesetvec1[3] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[0] : tag0_3[settagbusy1_addr];
+	    tag0_4[settagbusy1_addr] <= (wesetvec1[4] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[0] : tag0_4[settagbusy1_addr];
+	    //TAG1
+	    tag1_master[settagbusy1_addr] <= settagbusy1_prior2 ?
+					     settag1[1] : tag1_master[settagbusy1_addr];
+	    
+	    tag1_0[settagbusy1_addr] <= (wesetvec1[0] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[1] : tag1_0[settagbusy1_addr];
+	    tag1_1[settagbusy1_addr] <= (wesetvec1[1] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[1] : tag1_1[settagbusy1_addr];
+	    tag1_2[settagbusy1_addr] <= (wesetvec1[2] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[1] : tag1_2[settagbusy1_addr];
+	    tag1_3[settagbusy1_addr] <= (wesetvec1[3] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[1] : tag1_3[settagbusy1_addr];
+	    tag1_4[settagbusy1_addr] <= (wesetvec1[4] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[1] : tag1_4[settagbusy1_addr];
+	    //TAG2
+	    tag2_master[settagbusy1_addr] <= settagbusy1_prior2 ?
+					     settag1[2] : tag2_master[settagbusy1_addr];
+	    tag2_0[settagbusy1_addr] <= (wesetvec1[0] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[2] : tag2_0[settagbusy1_addr];
+	    tag2_1[settagbusy1_addr] <= (wesetvec1[1] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[2] : tag2_1[settagbusy1_addr];
+	    tag2_2[settagbusy1_addr] <= (wesetvec1[2] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[2] : tag2_2[settagbusy1_addr];
+	    tag2_3[settagbusy1_addr] <= (wesetvec1[3] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[2] : tag2_3[settagbusy1_addr];
+	    tag2_4[settagbusy1_addr] <= (wesetvec1[4] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[2] : tag2_4[settagbusy1_addr];
+	    //TAG3
+	    tag3_master[settagbusy1_addr] <= settagbusy1_prior2 ?
+					     settag1[3] : tag3_master[settagbusy1_addr];
+	    tag3_0[settagbusy1_addr] <= (wesetvec1[0] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[3] : tag3_0[settagbusy1_addr];
+	    tag3_1[settagbusy1_addr] <= (wesetvec1[1] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[3] : tag3_1[settagbusy1_addr];
+	    tag3_2[settagbusy1_addr] <= (wesetvec1[2] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[3] : tag3_2[settagbusy1_addr];
+	    tag3_3[settagbusy1_addr] <= (wesetvec1[3] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[3] : tag3_3[settagbusy1_addr];
+	    tag3_4[settagbusy1_addr] <= (wesetvec1[4] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[3] : tag3_4[settagbusy1_addr];
+	    //TAG4
+	    tag4_master[settagbusy1_addr] <= settagbusy1_prior2 ?
+					     settag1[4] : tag4_master[settagbusy1_addr];
+	    tag4_0[settagbusy1_addr] <= (wesetvec1[0] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[4] : tag4_0[settagbusy1_addr];
+	    tag4_1[settagbusy1_addr] <= (wesetvec1[1] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[4] : tag4_1[settagbusy1_addr];
+	    tag4_2[settagbusy1_addr] <= (wesetvec1[2] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[4] : tag4_2[settagbusy1_addr];
+	    tag4_3[settagbusy1_addr] <= (wesetvec1[3] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[4] : tag4_3[settagbusy1_addr];
+	    tag4_4[settagbusy1_addr] <= (wesetvec1[4] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[4] : tag4_4[settagbusy1_addr];
+	    //TAG5
+	    tag5_master[settagbusy1_addr] <= settagbusy1_prior2 ?
+					     settag1[5] : tag5_master[settagbusy1_addr];
+	    tag5_0[settagbusy1_addr] <= (wesetvec1[0] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[5] : tag5_0[settagbusy1_addr];
+	    tag5_1[settagbusy1_addr] <= (wesetvec1[1] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[5] : tag5_1[settagbusy1_addr];
+	    tag5_2[settagbusy1_addr] <= (wesetvec1[2] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[5] : tag5_2[settagbusy1_addr];
+	    tag5_3[settagbusy1_addr] <= (wesetvec1[3] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[5] : tag5_3[settagbusy1_addr];
+	    tag5_4[settagbusy1_addr] <= (wesetvec1[4] & 
+					 (settagbusy1_prior2 | 
+					  (setbusy1_spectag != setbusy2_spectag))) ?
+					settag1[5] : tag5_4[settagbusy1_addr];
+	    
+	 end // if (setttagbusy1)
+	 if (settagbusy2) begin
+	    //TAG0
+	    tag0_master[settagbusy2_addr] <= settag2[0];
+	    
+	    tag0_0[settagbusy2_addr] <= wesetvec2[0] ? 
+					settag2[0] : tag0_0[settagbusy2_addr];
+	    tag0_1[settagbusy2_addr] <= wesetvec2[1] ? 
+					settag2[0] : tag0_1[settagbusy2_addr];
+	    tag0_2[settagbusy2_addr] <= wesetvec2[2] ? 
+					settag2[0] : tag0_2[settagbusy2_addr];
+	    tag0_3[settagbusy2_addr] <= wesetvec2[3] ? 
+					settag2[0] : tag0_3[settagbusy2_addr];
+	    tag0_4[settagbusy2_addr] <= wesetvec2[4] ? 
+					settag2[0] : tag0_4[settagbusy2_addr];
+	    //TAG1
+	    tag1_master[settagbusy2_addr] <= settag2[1];
+	    
+	    tag1_0[settagbusy2_addr] <= wesetvec2[0] ? 
+					settag2[1] : tag1_0[settagbusy2_addr];
+	    tag1_1[settagbusy2_addr] <= wesetvec2[1] ? 
+					settag2[1] : tag1_1[settagbusy2_addr];
+	    tag1_2[settagbusy2_addr] <= wesetvec2[2] ? 
+					settag2[1] : tag1_2[settagbusy2_addr];
+	    tag1_3[settagbusy2_addr] <= wesetvec2[3] ? 
+					settag2[1] : tag1_3[settagbusy2_addr];
+	    tag1_4[settagbusy2_addr] <= wesetvec2[4] ? 
+					settag2[1] : tag1_4[settagbusy2_addr];
+	    //TAG2
+	    tag2_master[settagbusy2_addr] <= settag2[2];
+	    tag2_0[settagbusy2_addr] <= wesetvec2[0] ? 
+					settag2[2] : tag2_0[settagbusy2_addr];
+	    tag2_1[settagbusy2_addr] <= wesetvec2[1] ? 
+					settag2[2] : tag2_1[settagbusy2_addr];
+	    tag2_2[settagbusy2_addr] <= wesetvec2[2] ? 
+					settag2[2] : tag2_2[settagbusy2_addr];
+	    tag2_3[settagbusy2_addr] <= wesetvec2[3] ? 
+					settag2[2] : tag2_3[settagbusy2_addr];
+	    tag2_4[settagbusy2_addr] <= wesetvec2[4] ? 
+					settag2[2] : tag2_4[settagbusy2_addr];
+	    //TAG3
+	    tag3_master[settagbusy2_addr] <= settag2[3];
+	    tag3_0[settagbusy2_addr] <= wesetvec2[0] ? 
+					settag2[3] : tag3_0[settagbusy2_addr];
+	    tag3_1[settagbusy2_addr] <= wesetvec2[1] ? 
+					settag2[3] : tag3_1[settagbusy2_addr];
+	    tag3_2[settagbusy2_addr] <= wesetvec2[2] ? 
+					settag2[3] : tag3_2[settagbusy2_addr];
+	    tag3_3[settagbusy2_addr] <= wesetvec2[3] ? 
+					settag2[3] : tag3_3[settagbusy2_addr];
+	    tag3_4[settagbusy2_addr] <= wesetvec2[4] ? 
+					settag2[3] : tag3_4[settagbusy2_addr];
+	    //TAG4
+	    tag4_master[settagbusy2_addr] <= settag2[4];
+	    tag4_0[settagbusy2_addr] <= wesetvec2[0] ? 
+					settag2[4] : tag4_0[settagbusy2_addr];
+	    tag4_1[settagbusy2_addr] <= wesetvec2[1] ? 
+					settag2[4] : tag4_1[settagbusy2_addr];
+	    tag4_2[settagbusy2_addr] <= wesetvec2[2] ? 
+					settag2[4] : tag4_2[settagbusy2_addr];
+	    tag4_3[settagbusy2_addr] <= wesetvec2[3] ? 
+					settag2[4] : tag4_3[settagbusy2_addr];
+	    tag4_4[settagbusy2_addr] <= wesetvec2[4] ? 
+					settag2[4] : tag4_4[settagbusy2_addr];
+	    //TAG5
+	    tag5_master[settagbusy2_addr] <= settag2[5];
+	    tag5_0[settagbusy2_addr] <= wesetvec2[0] ? 
+					settag2[5] : tag5_0[settagbusy2_addr];
+	    tag5_1[settagbusy2_addr] <= wesetvec2[1] ? 
+					settag2[5] : tag5_1[settagbusy2_addr];
+	    tag5_2[settagbusy2_addr] <= wesetvec2[2] ? 
+					settag2[5] : tag5_2[settagbusy2_addr];
+	    tag5_3[settagbusy2_addr] <= wesetvec2[3] ? 
+					settag2[5] : tag5_3[settagbusy2_addr];
+	    tag5_4[settagbusy2_addr] <= wesetvec2[4] ? 
+					settag2[5] : tag5_4[settagbusy2_addr];
+	 end
+      end
+   end
+endmodule // renaming_table
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/brimm_gen.v
+++ b/examples/SQED_ridecore/rtl/design/brimm_gen.v
@@ -1,0 +1,24 @@
+`include "constants.vh"
+`include "rv32_opcodes.vh"
+`default_nettype none
+module brimm_gen
+  (
+   input wire [`INSN_LEN-1:0]  inst,
+   output wire [`DATA_LEN-1:0] brimm
+   );
+
+   wire [`DATA_LEN-1:0]        br_offset = { {20{inst[31]}}, inst[7], 
+					     inst[30:25], inst[11:8], 1'b0 };
+   wire [`DATA_LEN-1:0]        jal_offset = { {12{inst[31]}}, inst[19:12], 
+					      inst[20], inst[30:25], inst[24:21], 1'b0 };
+   wire [`DATA_LEN-1:0]        jalr_offset = { {21{inst[31]}}, inst[30:21], 1'b0 };
+
+   wire [6:0] 		       opcode = inst[6:0];
+   
+   assign brimm = (opcode == `RV32_BRANCH) ? br_offset :
+		  (opcode == `RV32_JAL) ? jal_offset :
+		  (opcode == `RV32_JALR) ? jalr_offset :
+		  `DATA_LEN'b0;
+
+endmodule // brimm_gen
+`default_nettype wire  

--- a/examples/SQED_ridecore/rtl/design/btb.v
+++ b/examples/SQED_ridecore/rtl/design/btb.v
@@ -1,0 +1,58 @@
+`include "constants.vh"
+`default_nettype none
+module btb(
+	   input wire 		       clk,
+	   input wire 		       reset,
+	   input wire [`ADDR_LEN-1:0]  pc,
+	   output wire 		       hit,
+	   output wire [`ADDR_LEN-1:0] jmpaddr,
+	   input wire 		       we,
+	   input wire [`ADDR_LEN-1:0]  jmpsrc,
+	   input wire [`ADDR_LEN-1:0]  jmpdst,
+	   input wire 		       invalid2
+	   );
+
+   wire [`ADDR_LEN-1:0] 	  tag_data;
+   reg [`BTB_IDX_NUM-1:0] 	  valid;
+   wire [`BTB_IDX_SEL-1:0] 	  waddr = jmpsrc[3+:`BTB_IDX_SEL];
+   wire [`ADDR_LEN-1:0] 	  pc2 = pc+4;
+   
+   wire 			  hit1 = ((tag_data == pc) && valid[pc[3+:`BTB_IDX_SEL]]) ? 
+				  1'b1 : 1'b0;
+   wire 			  hit2 = ((tag_data == pc2) && ~invalid2 
+					  && valid[pc[3+:`BTB_IDX_SEL]]) ? 1'b1 : 1'b0;
+   assign hit = hit1 | hit2;
+		
+   always @ (negedge clk) begin
+      if (reset) begin
+	 valid <= 0;
+      end else begin
+	 if (we) begin
+	    valid[waddr] <= 1'b1;
+	 end
+      end
+   end
+   
+   ram_sync_1r1w #(`BTB_IDX_SEL, `ADDR_LEN, `BTB_IDX_NUM) bia
+     (
+      .clk(~clk),
+      .raddr1(pc[3+:`BTB_IDX_SEL]),
+      .rdata1(tag_data),
+      .waddr(waddr),
+//    .wdata(jmpsrc[31:3+`BTB_IDX_SEL]),
+      .wdata(jmpsrc),
+      .we(we)
+      );
+
+   ram_sync_1r1w #(`BTB_IDX_SEL, `ADDR_LEN, `BTB_IDX_NUM) bta
+     (
+      .clk(~clk),
+      .raddr1(pc[3+:`BTB_IDX_SEL]),
+      .rdata1(jmpaddr),
+      .waddr(waddr),
+      .wdata(jmpdst),
+      .we(we)
+      );
+        
+endmodule // btb
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/constants.vh
+++ b/examples/SQED_ridecore/rtl/design/constants.vh
@@ -1,0 +1,110 @@
+//Register File
+`define REG_SEL 5
+//`define REG_NUM 2**`REG_SEL
+`define REG_NUM 32
+
+//Instruction
+`define IMM_TYPE_WIDTH 2
+`define IMM_I `IMM_TYPE_WIDTH'd0
+`define IMM_S `IMM_TYPE_WIDTH'd1
+`define IMM_U `IMM_TYPE_WIDTH'd2
+`define IMM_J `IMM_TYPE_WIDTH'd3
+
+//Important Wire
+`define DATA_LEN 32
+`define INSN_LEN 32
+`define ADDR_LEN 32
+`define ISSUE_NUM 2
+`define ENTRY_POINT `ADDR_LEN'h0
+//`define REQDATA_LEN 2
+
+//Decoder
+`define RS_ENT_SEL 3
+`define RS_ENT_ALU 1
+`define RS_ENT_BRANCH 2
+`define RS_ENT_JAL `RS_ENT_BRANCH
+`define RS_ENT_JALR `RS_ENT_BRANCH
+`define RS_ENT_MUL 3
+`define RS_ENT_DIV 3
+`define RS_ENT_LDST 4
+
+//RS
+`define ALU_ENT_SEL 3
+`define ALU_ENT_NUM 8
+`define BRANCH_ENT_SEL 2
+`define BRANCH_ENT_NUM 4
+`define LDST_ENT_SEL 2
+`define LDST_ENT_NUM 4
+//`define LDST_ENT_SEL 3
+//`define LDST_ENT_NUM 8
+`define MUL_ENT_SEL 1
+`define MUL_ENT_NUM 2
+
+//STOREBUFFER
+`define STBUF_ENT_SEL 5
+`define STBUF_ENT_NUM 32
+
+//BTB
+`define BTB_IDX_SEL 9
+`define BTB_IDX_NUM 512
+//`define BTB_IDX_NUM 2**`BTB_IDX_SEL
+//`define BTB_TAG_LEN `ADDR_LEN-3-`BTB_IDX_SEL
+`define BTB_TAG_LEN 20
+
+//Gshare
+`define GSH_BHR_LEN 10
+`define GSH_PHT_SEL 10
+`define GSH_PHT_NUM 1024
+//`define GSH_PHT_NUM 2**`GSH_PHT_SEL
+
+//TagGenerator
+
+//`define SPECTAG_LEN 1+`BRANCH_ENT_NUM
+`define SPECTAG_LEN 5
+//`define BRDEPTH_LEN `SPECTAG_LEN
+`define BRDEPTH_LEN 5
+
+//Re-Order Buffer
+`define ROB_SEL 6
+//`define ROB_NUM 2**`ROB_SEL
+`define ROB_NUM 64
+`define RRF_SEL `ROB_SEL
+`define RRF_NUM `ROB_NUM
+
+//src_a
+`define SRC_A_SEL_WIDTH 2
+`define SRC_A_RS1  `SRC_A_SEL_WIDTH'd0
+`define SRC_A_PC   `SRC_A_SEL_WIDTH'd1
+`define SRC_A_ZERO `SRC_A_SEL_WIDTH'd2
+
+//src_b
+`define SRC_B_SEL_WIDTH 2
+`define SRC_B_RS2  `SRC_B_SEL_WIDTH'd0
+`define SRC_B_IMM  `SRC_B_SEL_WIDTH'd1
+`define SRC_B_FOUR `SRC_B_SEL_WIDTH'd2
+`define SRC_B_ZERO `SRC_B_SEL_WIDTH'd3
+
+`define MEM_TYPE_WIDTH 3
+`define MEM_TYPE_LB  `MEM_TYPE_WIDTH'd0
+`define MEM_TYPE_LH  `MEM_TYPE_WIDTH'd1
+`define MEM_TYPE_LW  `MEM_TYPE_WIDTH'd2
+`define MEM_TYPE_LD  `MEM_TYPE_WIDTH'd3
+`define MEM_TYPE_LBU `MEM_TYPE_WIDTH'd4
+`define MEM_TYPE_LHU `MEM_TYPE_WIDTH'd5
+`define MEM_TYPE_LWU `MEM_TYPE_WIDTH'd6
+
+`define MEM_TYPE_SB  `MEM_TYPE_WIDTH'd0
+`define MEM_TYPE_SH  `MEM_TYPE_WIDTH'd1
+`define MEM_TYPE_SW  `MEM_TYPE_WIDTH'd2
+`define MEM_TYPE_SD  `MEM_TYPE_WIDTH'd3
+
+`define MD_OP_WIDTH 2
+`define MD_OP_MUL `MD_OP_WIDTH'd0
+`define MD_OP_DIV `MD_OP_WIDTH'd1
+`define MD_OP_REM `MD_OP_WIDTH'd2
+
+`define MD_OUT_SEL_WIDTH 2
+`define MD_OUT_LO  `MD_OUT_SEL_WIDTH'd0
+`define MD_OUT_HI  `MD_OUT_SEL_WIDTH'd1
+`define MD_OUT_REM `MD_OUT_SEL_WIDTH'd2
+

--- a/examples/SQED_ridecore/rtl/design/decoder.v
+++ b/examples/SQED_ridecore/rtl/design/decoder.v
@@ -1,0 +1,259 @@
+`include "constants.vh"
+`include "rv32_opcodes.vh"
+`include "alu_ops.vh"
+
+`default_nettype none
+module decoder(
+	       input wire [31:0] 		  inst,
+	       output reg [`IMM_TYPE_WIDTH-1:0]   imm_type,
+	       output wire [`REG_SEL-1:0] 	  rs1,
+	       output wire [`REG_SEL-1:0] 	  rs2,
+	       output wire [`REG_SEL-1:0] 	  rd,
+	       output reg [`SRC_A_SEL_WIDTH-1:0]  src_a_sel,
+               output reg [`SRC_B_SEL_WIDTH-1:0]  src_b_sel,
+	       output reg 			  wr_reg,
+	       
+	       output reg 			  uses_rs1,
+	       output reg 			  uses_rs2,
+	       output reg 			  illegal_instruction,
+	       output reg [`ALU_OP_WIDTH-1:0] 	  alu_op,
+	       output reg [`RS_ENT_SEL-1:0] 	  rs_ent,
+//	       output reg 			  dmem_use,
+//	       output reg 			  dmem_write,
+	       output wire [2:0] 		  dmem_size,
+	       output wire [`MEM_TYPE_WIDTH-1:0]  dmem_type, 
+	       output reg [`MD_OP_WIDTH-1:0] 	  md_req_op,
+	       output reg 			  md_req_in_1_signed,
+	       output reg 			  md_req_in_2_signed,
+	       output reg [`MD_OUT_SEL_WIDTH-1:0] md_req_out_sel
+
+	       );
+
+   wire [`ALU_OP_WIDTH-1:0] 			  srl_or_sra;
+   wire [`ALU_OP_WIDTH-1:0] 			  add_or_sub;
+   wire [`RS_ENT_SEL-1:0] 			  rs_ent_md;
+   
+   wire [6:0] 		    opcode = inst[6:0];
+   wire [6:0] 		    funct7 = inst[31:25];
+   wire [11:0] 		    funct12 = inst[31:20];
+   wire [2:0] 		    funct3 = inst[14:12];
+// reg [`MD_OP_WIDTH-1:0]   md_req_op;
+   reg [`ALU_OP_WIDTH-1:0]  alu_op_arith;
+   
+   assign rd = inst[11:7];
+   assign rs1 = inst[19:15];
+   assign rs2 = inst[24:20];
+
+   assign dmem_size = {1'b0,funct3[1:0]};
+   assign dmem_type = funct3;
+   
+   always @ (*) begin
+      imm_type = `IMM_I;
+      src_a_sel = `SRC_A_RS1;
+      src_b_sel = `SRC_B_IMM;
+      wr_reg = 1'b0;
+      uses_rs1 = 1'b1;
+      uses_rs2 = 1'b0;
+      illegal_instruction = 1'b0;
+      //      dmem_use = 1'b0;
+      //     dmem_write = 1'b0;
+      rs_ent = `RS_ENT_ALU;
+      alu_op = `ALU_OP_ADD;
+      
+      case (opcode)
+	`RV32_LOAD : begin
+//           dmem_use = 1'b1;
+           wr_reg = 1'b1;
+	   rs_ent = `RS_ENT_LDST;
+//           wb_src_sel_DX = `WB_SRC_MEM;
+        end
+        `RV32_STORE : begin
+           uses_rs2 = 1'b1;
+           imm_type = `IMM_S;
+//           dmem_use = 1'b1;
+ //          dmem_write = 1'b1;
+	   rs_ent = `RS_ENT_LDST;
+        end
+        `RV32_BRANCH : begin
+           uses_rs2 = 1'b1;
+           //branch_taken_unkilled = cmp_true;
+           src_b_sel = `SRC_B_RS2;
+           case (funct3)
+             `RV32_FUNCT3_BEQ : alu_op = `ALU_OP_SEQ;
+             `RV32_FUNCT3_BNE : alu_op = `ALU_OP_SNE;
+             `RV32_FUNCT3_BLT : alu_op = `ALU_OP_SLT;
+             `RV32_FUNCT3_BLTU : alu_op = `ALU_OP_SLTU;
+             `RV32_FUNCT3_BGE : alu_op = `ALU_OP_SGE;
+             `RV32_FUNCT3_BGEU : alu_op = `ALU_OP_SGEU;
+             default : illegal_instruction = 1'b1;
+           endcase // case (funct3)
+	   rs_ent = `RS_ENT_BRANCH;
+        end
+        `RV32_JAL : begin
+	   //           jal_unkilled = 1'b1;
+           uses_rs1 = 1'b0;
+           src_a_sel = `SRC_A_PC;
+           src_b_sel = `SRC_B_FOUR;
+           wr_reg = 1'b1;
+	   rs_ent = `RS_ENT_JAL;
+        end
+        `RV32_JALR : begin
+           illegal_instruction = (funct3 != 0);
+	   //           jalr_unkilled = 1'b1;
+           src_a_sel = `SRC_A_PC;
+           src_b_sel = `SRC_B_FOUR;
+           wr_reg = 1'b1;
+	   rs_ent = `RS_ENT_JALR;
+        end
+	/*
+        `RV32_MISC_MEM : begin
+           case (funct3)
+             `RV32_FUNCT3_FENCE : begin
+                if ((inst[31:28] == 0) && (rs1 == 0) && (reg_to_wr_DX == 0))
+                  ; // most fences are no-ops
+                else
+                  illegal_instruction = 1'b1;
+             end
+             `RV32_FUNCT3_FENCE_I : begin
+                if ((inst[31:20] == 0) && (rs1 == 0) && (reg_to_wr_DX == 0))
+                  fence_i = 1'b1;
+                else
+                  illegal_instruction = 1'b1;
+             end
+             default : illegal_instruction = 1'b1;
+           endcase // case (funct3)
+        end
+	 */
+        `RV32_OP_IMM : begin
+           alu_op = alu_op_arith;
+           wr_reg = 1'b1;
+        end
+        `RV32_OP  : begin
+           uses_rs2 = 1'b1;
+           src_b_sel = `SRC_B_RS2;
+           alu_op = alu_op_arith;
+           wr_reg = 1'b1;
+           if (funct7 == `RV32_FUNCT7_MUL_DIV) begin
+//              uses_md_unkilled = 1'b1;
+	      rs_ent = rs_ent_md;
+//              wb_src_sel_DX = `WB_SRC_MD;
+           end
+        end
+	/*
+        `RV32_SYSTEM : begin
+           wb_src_sel_DX = `WB_SRC_CSR;
+           wr_reg = (funct3 != `RV32_FUNCT3_PRIV);
+           case (funct3)
+             `RV32_FUNCT3_PRIV : begin
+                if ((rs1 == 0) && (reg_to_wr_DX == 0)) begin
+                   case (funct12)
+                     `RV32_FUNCT12_ECALL : ecall = 1'b1;
+                     `RV32_FUNCT12_EBREAK : ebreak = 1'b1;
+                     `RV32_FUNCT12_ERET : begin
+                        if (prv == 0)
+                          illegal_instruction = 1'b1;
+                        else
+                          eret_unkilled = 1'b1;
+                     end
+                     default : illegal_instruction = 1'b1;
+                   endcase // case (funct12)
+                end // if ((rs1 == 0) && (reg_to_wr_DX == 0))
+             end // case: `RV32_FUNCT3_PRIV
+             `RV32_FUNCT3_CSRRW : csr_cmd = (rs1 == 0) ? `CSR_READ : `CSR_WRITE;
+             `RV32_FUNCT3_CSRRS : csr_cmd = (rs1 == 0) ? `CSR_READ : `CSR_SET;
+             `RV32_FUNCT3_CSRRC : csr_cmd = (rs1 == 0) ? `CSR_READ : `CSR_CLEAR;
+             `RV32_FUNCT3_CSRRWI : csr_cmd = (rs1 == 0) ? `CSR_READ : `CSR_WRITE;
+             `RV32_FUNCT3_CSRRSI : csr_cmd = (rs1 == 0) ? `CSR_READ : `CSR_SET;
+             `RV32_FUNCT3_CSRRCI : csr_cmd = (rs1 == 0) ? `CSR_READ : `CSR_CLEAR;
+             default : illegal_instruction = 1'b1;
+           endcase // case (funct3)
+        end
+	 */
+        `RV32_AUIPC : begin
+           uses_rs1 = 1'b0;
+           src_a_sel = `SRC_A_PC;
+           imm_type = `IMM_U;
+           wr_reg = 1'b1;
+        end
+        `RV32_LUI : begin
+           uses_rs1 = 1'b0;
+           src_a_sel = `SRC_A_ZERO;
+           imm_type = `IMM_U;
+           wr_reg = 1'b1;
+        end
+        default : begin
+           illegal_instruction = 1'b1;
+        end
+      endcase // case (opcode)
+   end // always @ (*)
+
+   assign add_or_sub = ((opcode == `RV32_OP) && (funct7[5])) ? `ALU_OP_SUB : `ALU_OP_ADD;
+   assign srl_or_sra = (funct7[5]) ? `ALU_OP_SRA : `ALU_OP_SRL;
+
+   always @(*) begin
+      case (funct3)
+        `RV32_FUNCT3_ADD_SUB : alu_op_arith = add_or_sub;
+        `RV32_FUNCT3_SLL : alu_op_arith = `ALU_OP_SLL;
+        `RV32_FUNCT3_SLT : alu_op_arith = `ALU_OP_SLT;
+        `RV32_FUNCT3_SLTU : alu_op_arith = `ALU_OP_SLTU;
+        `RV32_FUNCT3_XOR : alu_op_arith = `ALU_OP_XOR;
+        `RV32_FUNCT3_SRA_SRL : alu_op_arith = srl_or_sra;
+        `RV32_FUNCT3_OR : alu_op_arith = `ALU_OP_OR;
+        `RV32_FUNCT3_AND : alu_op_arith = `ALU_OP_AND;
+        default : alu_op_arith = `ALU_OP_ADD;
+      endcase // case (funct3)
+   end // always @ begin
+
+
+   //assign md_req_valid = uses_md;
+   assign rs_ent_md = (
+		       (funct3 == `RV32_FUNCT3_MUL) ||
+		       (funct3 == `RV32_FUNCT3_MULH) ||
+		       (funct3 == `RV32_FUNCT3_MULHSU) ||
+		       (funct3 == `RV32_FUNCT3_MULHU)
+		       ) ? `RS_ENT_MUL : `RS_ENT_DIV;
+   
+   always @(*) begin
+      md_req_op = `MD_OP_MUL;
+      md_req_in_1_signed = 0;
+      md_req_in_2_signed = 0;
+      md_req_out_sel = `MD_OUT_LO;
+      case (funct3)
+        `RV32_FUNCT3_MUL : begin
+        end
+        `RV32_FUNCT3_MULH : begin
+           md_req_in_1_signed = 1;
+           md_req_in_2_signed = 1;
+           md_req_out_sel = `MD_OUT_HI;
+        end
+        `RV32_FUNCT3_MULHSU : begin
+           md_req_in_1_signed = 1;
+           md_req_out_sel = `MD_OUT_HI;
+        end
+        `RV32_FUNCT3_MULHU : begin
+           md_req_out_sel = `MD_OUT_HI;
+        end
+        `RV32_FUNCT3_DIV : begin
+           md_req_op = `MD_OP_DIV;
+           md_req_in_1_signed = 1;
+           md_req_in_2_signed = 1;
+        end
+        `RV32_FUNCT3_DIVU : begin
+           md_req_op = `MD_OP_DIV;
+        end
+        `RV32_FUNCT3_REM : begin
+           md_req_op = `MD_OP_REM;
+           md_req_in_1_signed = 1;
+           md_req_in_2_signed = 1;
+           md_req_out_sel = `MD_OUT_REM;
+        end
+        `RV32_FUNCT3_REMU : begin
+           md_req_op = `MD_OP_REM;
+           md_req_out_sel = `MD_OUT_REM;
+        end
+      endcase
+   end
+
+   
+endmodule // decoder
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/define.v
+++ b/examples/SQED_ridecore/rtl/design/define.v
@@ -1,0 +1,33 @@
+/**************************************************************************************************/
+/* Many-core processor project Arch Lab.                                               TOKYO TECH */
+/**************************************************************************************************/
+//`default_nettype none
+/**************************************************************************************************/
+
+/* Clock Frequency Definition                                                                     */
+/* Clock Freq = (System Clock Freq) * (DCM_CLKFX_MULTIPLY) / (DCM_CLKFX_DIVIDE)                   */
+/**************************************************************************************************/
+`define SYSTEM_CLOCK_FREQ   200    // Atlys -> 100 MHz, Nexys4 -> 100 MHz, Virtex7 -> 200 MHz
+
+`define DCM_CLKIN_PERIOD    5.000  // Atlys -> 10.000 ns
+`define DCM_CLKFX_MULTIPLY  3      // CLKFX_MULTIPLY must be 2~32
+`define DCM_CLKFX_DIVIDE    25     // CLKFX_DIVIDE   must be 1~32
+
+`define MMCM_CLKIN1_PERIOD  5.000  // Nexys4 -> 10.000 ns, Virtex7 -> 5.000 ns
+`define MMCM_VCO_MULTIPLY   8      // for VCO, 800-1600
+`define MMCM_VCO_DIVIDE     2
+`define MMCM_CLKOUT0_DIVIDE 16     // for user clock, 50  MHz
+`define MMCM_CLKOUT1_DIVIDE 4      // for dram clock, 200 MHz
+
+
+/* UART Definition                                                                                */
+/**************************************************************************************************/
+`define SERIAL_WCNT  'd50       // 24MHz/1.5Mbaud, parameter for UartRx and UartTx
+`define APP_SIZE        8*1024  // application program load size in byte (64*16=1024KB)
+`define SCD_SIZE       64*1024  // scheduling program  load size in byte (64* 1=  64KB)
+`define IMG_SIZE     1088*1024  // full image file     load size in byte (64*17=1088KB)
+
+
+/**************************************************************************************************/
+//`default_nettype wire
+/**************************************************************************************************/

--- a/examples/SQED_ridecore/rtl/design/dmem.v
+++ b/examples/SQED_ridecore/rtl/design/dmem.v
@@ -1,0 +1,24 @@
+`include "constants.vh"
+`default_nettype none
+//8KB Single PORT synchronous BRAM
+module dmem
+  (
+   input wire 		      clk,
+   input wire [`ADDR_LEN-1:0] addr,
+   input wire [`DATA_LEN-1:0] wdata,
+   input wire 		      we,
+   output reg [`DATA_LEN-1:0] rdata
+   );
+
+   // EDIT
+   reg[`DATA_LEN-1:0] mem[0:2047];
+   //reg [`DATA_LEN-1:0] 	      mem [0:31];
+   // EDIT: END
+
+   always @ (posedge clk) begin
+      rdata <= mem[addr[10:0]];
+      if (we)
+	mem[addr] <= wdata;
+   end
+endmodule // dmem
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/dualport_ram.v
+++ b/examples/SQED_ridecore/rtl/design/dualport_ram.v
@@ -1,0 +1,82 @@
+`include "constants.vh"
+`default_nettype none
+module true_dualport_ram #(
+			   parameter ADDRLEN = 10,
+			   parameter DATALEN = 2,
+			   parameter DEPTH = 1024
+			   )
+   (
+    input wire 		     clka,
+    input wire [ADDRLEN-1:0] addra,
+    output reg [DATALEN-1:0] rdataa,
+    input wire [DATALEN-1:0] wdataa,
+    input wire 		     wea,
+    input wire 		     clkb,
+    input wire [ADDRLEN-1:0] addrb,
+    output reg [DATALEN-1:0] rdatab,
+    input wire [DATALEN-1:0] wdatab,
+    input wire 		     web
+    );
+
+
+   reg [DATALEN-1:0] 				  mem [0:DEPTH-1];
+   
+   always @ (posedge clka) begin
+      rdataa <= mem[addra];
+      if (wea) begin
+	 mem[addra] <= wdataa;
+      end
+   end
+
+   always @ (posedge clkb) begin
+      rdatab <= mem[addrb];
+      if (web) begin
+	 mem[addrb] <= wdatab;
+      end
+   end
+endmodule // true_dualport_ram
+
+module true_dualport_ram_clear #(
+				 parameter ADDRLEN = 10,
+				 parameter DATALEN = 2,
+				 parameter DEPTH = 1024
+				 )
+   (
+    input wire 		     clka,
+    input wire [ADDRLEN-1:0] addra,
+    output reg [DATALEN-1:0] rdataa,
+    input wire [DATALEN-1:0] wdataa,
+    input wire 		     wea,
+    input wire 		     clkb,
+    input wire [ADDRLEN-1:0] addrb,
+    output reg [DATALEN-1:0] rdatab,
+    input wire [DATALEN-1:0] wdatab,
+    input wire 		     web,
+    input wire 		     clear
+    );
+
+   reg [DATALEN-1:0] 					mem [0:DEPTH-1];
+   integer 						i;
+   
+   always @ (*) begin
+      if (clear) begin
+	 for (i=0; i<DEPTH; i=i+1)
+	   mem[i] = 0;
+      end
+   end
+   
+   always @ (posedge clka) begin
+      rdataa <= mem[addra];
+      if (wea) begin
+	 mem[addra] <= wdataa;
+      end
+   end
+
+   always @ (posedge clkb) begin
+      rdatab <= mem[addrb];
+      if (web) begin
+	 mem[addrb] <= wdatab;
+      end
+   end
+endmodule // true_dualport_ram
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/exunit_alu.v
+++ b/examples/SQED_ridecore/rtl/design/exunit_alu.v
@@ -1,0 +1,75 @@
+`include "constants.vh"
+`include "alu_ops.vh"
+`default_nettype none
+module exunit_alu
+  (
+   input wire 			     clk,
+   input wire 			     reset,
+   input wire [`DATA_LEN-1:0] 	     ex_src1,
+   input wire [`DATA_LEN-1:0] 	     ex_src2,
+   input wire [`ADDR_LEN-1:0] 	     pc,
+   input wire [`DATA_LEN-1:0] 	     imm,
+   input wire 			     dstval,
+   input wire [`SRC_A_SEL_WIDTH-1:0] src_a,
+   input wire [`SRC_B_SEL_WIDTH-1:0] src_b,
+   input wire [`ALU_OP_WIDTH-1:0]    alu_op,
+   input wire [`SPECTAG_LEN-1:0]     spectag,
+   input wire 			     specbit,
+   input wire 			     issue,
+   input wire 			     prmiss,
+   input wire [`SPECTAG_LEN-1:0]     spectagfix,
+   output wire [`DATA_LEN-1:0] 	     result,
+   output wire 			     rrf_we,
+   output wire 			     rob_we, //set finish
+   output wire 			     kill_speculative
+   );
+
+   wire [`DATA_LEN-1:0] 	alusrc1;
+   wire [`DATA_LEN-1:0] 	alusrc2;
+
+   reg 				busy;
+
+   assign rob_we = busy;
+   assign rrf_we = busy & dstval;
+   assign kill_speculative = ((spectag & spectagfix) != 0) && specbit && prmiss;
+   
+   always @ (posedge clk) begin
+      if (reset) begin
+	 busy <= 0;
+      end else begin
+	 busy <= issue;
+      end
+   end
+   
+   src_a_mux samx
+     (
+      .src_a_sel(src_a),
+      .pc(pc),
+      .rs1(ex_src1),
+      .alu_src_a(alusrc1)
+      );
+
+   src_b_mux sbmx
+     (
+      .src_b_sel(src_b),
+      .imm(imm),
+      // EDIT mutation: Source operand input redirection in the ALU execution unit
+      .rs2(ex_src2),
+      //.rs2(ex_src1),
+      // END EDIT
+      .alu_src_b(alusrc2)
+      );
+
+   alu alice
+     (
+      .op(alu_op),
+      .in1(alusrc1),
+      //EDIT mutation: Source operand output redirection in the ALU execution unit
+      .in2(alusrc2),
+      //.in2(alusrc1),
+      // END EDIT
+      .out(result)
+      );
+endmodule // exunit_alu
+`default_nettype wire
+   

--- a/examples/SQED_ridecore/rtl/design/exunit_branch.v
+++ b/examples/SQED_ridecore/rtl/design/exunit_branch.v
@@ -1,0 +1,66 @@
+`include "constants.vh"
+`include "alu_ops.vh"
+`include "rv32_opcodes.vh"
+`default_nettype none
+module exunit_branch
+  (
+   input wire 			  clk,
+   input wire 			  reset,
+   input wire [`DATA_LEN-1:0] 	  ex_src1,
+   input wire [`DATA_LEN-1:0] 	  ex_src2,
+   input wire [`ADDR_LEN-1:0] 	  pc,
+   input wire [`DATA_LEN-1:0] 	  imm,
+   input wire 			  dstval,
+   input wire [`ALU_OP_WIDTH-1:0] alu_op,
+   input wire [`SPECTAG_LEN-1:0]  spectag,
+   input wire 			  specbit,
+   input wire [`ADDR_LEN-1:0] 	  praddr,
+   input wire [6:0] 		  opcode,
+   input wire 			  issue,
+   output wire [`DATA_LEN-1:0] 	  result,
+   output wire 			  rrf_we,
+   output wire 			  rob_we, //set finish
+   output wire 			  prsuccess,
+   output wire 			  prmiss,
+   output wire [`ADDR_LEN-1:0] 	  jmpaddr,
+   output wire [`ADDR_LEN-1:0] 	  jmpaddr_taken,
+   output wire 			  brcond,
+   output wire [`SPECTAG_LEN-1:0] tagregfix
+   );
+
+   reg 			       busy;
+   
+   wire [`DATA_LEN-1:0]        comprslt;
+   wire 		       addrmatch = (jmpaddr == praddr) ? 1'b1 : 1'b0;
+   
+   assign rob_we = busy;
+   assign rrf_we = busy & dstval;
+   assign result = pc + 4;
+   assign prsuccess = busy & addrmatch;
+   assign prmiss = busy & ~addrmatch;
+   assign jmpaddr = brcond ? jmpaddr_taken : (pc + 4);
+   assign jmpaddr_taken = (((opcode == `RV32_JALR) ? ex_src1 : pc) + imm);
+   
+   assign brcond = ((opcode == `RV32_JAL) || (opcode == `RV32_JALR)) ?
+			       1'b1 : comprslt[0];
+   assign tagregfix = {spectag[0], spectag[`SPECTAG_LEN-1:1]};
+   
+   always @ (posedge clk) begin
+      if (reset) begin
+	 busy <= 0;
+      end else begin
+	 busy <= issue;
+      end
+   end
+		  
+   alu comparator
+     (
+      .op(alu_op),
+      .in1(ex_src1),
+      .in2(ex_src2),
+      .out(comprslt)
+      );
+   
+endmodule // exunit_branch
+
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/exunit_ldst.v
+++ b/examples/SQED_ridecore/rtl/design/exunit_ldst.v
@@ -1,0 +1,99 @@
+`include "constants.vh"
+`include "alu_ops.vh"
+//`default_nettype none
+
+module exunit_ldst
+  (
+   input wire 			 clk,
+   input wire 			 reset,
+   input wire [`DATA_LEN-1:0] 	 ex_src1,
+   input wire [`DATA_LEN-1:0] 	 ex_src2,
+   input wire [`ADDR_LEN-1:0] 	 pc,
+   input wire [`DATA_LEN-1:0] 	 imm,
+   input wire 			 dstval,
+   input wire [`SPECTAG_LEN-1:0] spectag,
+   input wire 			 specbit,
+   input wire 			 issue,
+   input wire 			 prmiss,
+   input wire [`SPECTAG_LEN-1:0] spectagfix,
+   input wire [`RRF_SEL-1:0] 	 rrftag,
+   output wire [`DATA_LEN-1:0] 	 result,
+   output wire 			 rrf_we,
+   output wire 			 rob_we, //set finish
+   output wire [`RRF_SEL-1:0] 	 wrrftag,
+   output wire 			 kill_speculative,
+   output wire 			 busy_next,
+   //Signal StoreBuf
+   output wire 			 stfin,
+   //Store
+   output wire 			 memoccupy_ld,
+   input wire 			 fullsb,
+   output wire [`DATA_LEN-1:0] 	 storedata,
+   output wire [`ADDR_LEN-1:0] 	 storeaddr,
+   //Load
+   input wire 			 hitsb,
+   output wire [`ADDR_LEN-1:0] 	 ldaddr,
+   input wire [`DATA_LEN-1:0] 	 lddatasb,
+   input wire [`DATA_LEN-1:0] 	 lddatamem
+   );
+
+   reg 				 busy;
+   wire 			 clearbusy;
+   wire [`ADDR_LEN-1:0] 	 effaddr;
+   wire 			 killspec1;
+   
+   //LATCH
+   reg 				 dstval_latch;
+   reg [`RRF_SEL-1:0] 		 rrftag_latch;
+   reg 				 specbit_latch;
+   reg [`SPECTAG_LEN-1:0] 	 spectag_latch;
+   reg [`DATA_LEN-1:0] 		 lddatasb_latch;
+   reg 				 hitsb_latch;
+   reg 				 insnvalid_latch;
+
+   assign clearbusy = (killspec1 || dstval || (~dstval && ~fullsb)) ? 1'b1 : 1'b0;
+   assign killspec1 = ((spectag & spectagfix) != 0) && specbit && prmiss;
+   assign kill_speculative = ((spectag_latch & spectagfix) != 0) && specbit_latch && prmiss;
+   assign result = hitsb_latch ? lddatasb_latch : lddatamem;
+   assign rrf_we = dstval_latch & insnvalid_latch;
+   assign rob_we = insnvalid_latch;
+   assign wrrftag = rrftag_latch;
+   assign busy_next = clearbusy ? 1'b0 : busy;
+   assign stfin = ~killspec1 & busy & ~dstval;
+   assign memoccupy_ld = ~killspec1 & busy & dstval;
+   assign storedata = ex_src2;
+   assign storeaddr = effaddr;
+   assign ldaddr = effaddr;
+   assign effaddr = ex_src1 + imm;
+   
+   always @ (posedge clk) begin
+      if (reset | killspec1 | ~busy | (~dstval & fullsb)) begin
+	 dstval_latch <= 0;
+	 rrftag_latch <= 0;
+	 specbit_latch <= 0;
+	 spectag_latch <= 0;
+	 lddatasb_latch <= 0;
+	 hitsb_latch <= 0;
+	 insnvalid_latch <= 0;
+      end else begin
+	 dstval_latch <= dstval;
+	 rrftag_latch <= rrftag;
+	 specbit_latch <= specbit;
+	 spectag_latch <= spectag;
+	 lddatasb_latch <= lddatasb;
+	 hitsb_latch <= hitsb;
+	 insnvalid_latch <= ~killspec1 & ((busy & dstval) |
+					  (busy & ~dstval & ~fullsb));
+      end
+   end // always @ (posedge clk)
+
+   always @ (posedge clk) begin
+      if (reset | killspec1) begin
+	 busy <= 0;
+      end else begin
+	 busy <= issue | busy_next;
+      end
+   end
+endmodule // exunit_ldst
+
+//`default_nettype none

--- a/examples/SQED_ridecore/rtl/design/exunit_mul.v
+++ b/examples/SQED_ridecore/rtl/design/exunit_mul.v
@@ -1,0 +1,54 @@
+`include "constants.vh"
+`default_nettype none
+module exunit_mul
+  (
+   input wire 			 clk,
+   input wire 			 reset,
+   input wire [`DATA_LEN-1:0] 	 ex_src1,
+   input wire [`DATA_LEN-1:0] 	 ex_src2,
+   input wire 			 dstval,
+   input wire [`SPECTAG_LEN-1:0] spectag,
+   input wire 			 specbit,
+   input wire 			 src1_signed,
+   input wire 			 src2_signed,
+   input wire 			 sel_lohi,
+   input wire 			 issue,
+   input wire 			 prmiss,
+   input wire [`SPECTAG_LEN-1:0] spectagfix,
+   output wire [`DATA_LEN-1:0] 	 result,
+   output wire 			 rrf_we,
+   output wire 			 rob_we, //set finish
+   output wire 			 kill_speculative
+   );
+
+   reg 			       busy;
+   
+   assign rob_we = busy;
+   assign rrf_we = busy & dstval;
+   assign kill_speculative = ((spectag & spectagfix) != 0) && specbit && prmiss;
+   
+   always @ (posedge clk) begin
+      if (reset) begin
+	 busy <= 0;
+      end else begin
+	 busy <= issue;
+      end
+   end
+   
+   multiplier bob
+     (
+      .src1(ex_src1),
+      //EDIT mutation: Unsigned multiplication instruction source operand redirection
+      .src2(ex_src2),
+      //.src2(ex_src1),
+      // END EDIT
+      .src1_signed(src1_signed),
+      .src2_signed(src2_signed),
+      .sel_lohi(sel_lohi),
+      .result(result)
+      );
+   
+endmodule // exunit_mul
+
+   
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/gshare.v
+++ b/examples/SQED_ridecore/rtl/design/gshare.v
@@ -1,0 +1,174 @@
+`include "constants.vh"
+
+/*
+ ATTENTION!!!!!!!!!!!!!!!!!
+ BHR in this code must change when spectag_len is changed
+ */
+`default_nettype none
+module sel_bhrfix(
+		  input wire [4:0] 		sel,
+		  input wire [`GSH_BHR_LEN-1:0] bhr0,
+		  input wire [`GSH_BHR_LEN-1:0] bhr1,
+		  input wire [`GSH_BHR_LEN-1:0] bhr2,
+		  input wire [`GSH_BHR_LEN-1:0] bhr3,
+		  input wire [`GSH_BHR_LEN-1:0] bhr4,
+		  output reg [`GSH_BHR_LEN-1:0] out
+		  );
+   always @ (*) begin
+      out = 0;
+      case (sel)
+	5'b00001 : out = bhr0;
+	5'b00010 : out = bhr1;
+	5'b00100 : out = bhr2;
+	5'b01000 : out = bhr3;
+	5'b10000 : out = bhr4;
+	default : out = 0;
+      endcase // case (sel)
+   end
+   
+endmodule // sel_bhr
+
+//PRTAG is tag of prmiss/success branch instruction's
+module gshare_predictor
+  (
+   input wire 			 clk,
+   input wire 			 reset,
+   input wire [`ADDR_LEN-1:0] 	 pc,
+   input wire 			 hit_bht,
+   output wire 			 predict_cond,
+   input wire 			 we,
+   input wire 			 wcond,
+   input wire [`GSH_PHT_SEL-1:0] went,
+   input wire [`SPECTAG_LEN-1:0] mpft_valid,
+   input wire 			 prmiss,
+   input wire 			 prsuccess,
+   input wire [`SPECTAG_LEN-1:0] prtag,
+   output reg [`GSH_BHR_LEN-1:0] bhr_master,
+   input wire [`SPECTAG_LEN-1:0] spectagnow
+   );
+
+   reg [`GSH_BHR_LEN-1:0] 	 bhr0;
+   reg [`GSH_BHR_LEN-1:0] 	 bhr1;
+   reg [`GSH_BHR_LEN-1:0] 	 bhr2;
+   reg [`GSH_BHR_LEN-1:0] 	 bhr3;
+   reg [`GSH_BHR_LEN-1:0] 	 bhr4;
+   wire [`GSH_BHR_LEN-1:0] 	 bhr_fix;
+   wire [1:0] 			 rif;
+   wire [1:0] 			 rex;
+   wire [1:0] 			 wex;
+   wire [2:0] 			 wex_calc;
+   
+   sel_bhrfix sb(
+		 .sel(prtag),
+		 .bhr0(bhr0),
+		 .bhr1(bhr1),
+		 .bhr2(bhr2),
+		 .bhr3(bhr3),
+		 .bhr4(bhr4),
+		 .out(bhr_fix)
+		 );
+   
+   always @ (posedge clk) begin
+      if (reset) begin
+	 bhr0 <= 0;
+	 bhr1 <= 0;
+	 bhr2 <= 0;
+	 bhr3 <= 0;
+	 bhr4 <= 0;
+	 bhr_master <= 0;
+      end else if (prmiss) begin
+	 bhr0 <= bhr_fix;
+	 bhr1 <= bhr_fix;
+	 bhr2 <= bhr_fix;
+	 bhr3 <= bhr_fix;
+	 bhr4 <= bhr_fix;
+	 bhr_master <= bhr_fix;
+      end else if (prsuccess) begin
+	 bhr0 <= (prtag == 5'b00001) ? {bhr_master[`GSH_BHR_LEN-2:0], predict_cond} : bhr0; 
+	 bhr1 <= (prtag == 5'b00010) ? {bhr_master[`GSH_BHR_LEN-2:0], predict_cond} : bhr1;
+	 bhr2 <= (prtag == 5'b00100) ? {bhr_master[`GSH_BHR_LEN-2:0], predict_cond} : bhr2;
+	 bhr3 <= (prtag == 5'b01000) ? {bhr_master[`GSH_BHR_LEN-2:0], predict_cond} : bhr3;
+	 bhr4 <= (prtag == 5'b10000) ? {bhr_master[`GSH_BHR_LEN-2:0], predict_cond} : bhr4;
+      end else if (hit_bht) begin
+	 if (we & mpft_valid[0]) begin
+	    bhr0 <= {bhr0[`GSH_BHR_LEN-2:0], predict_cond};
+	 end
+	 if (we & mpft_valid[1]) begin
+	    bhr1 <= {bhr1[`GSH_BHR_LEN-2:0], predict_cond};
+	 end
+	 if (we & mpft_valid[2]) begin
+	    bhr2 <= {bhr2[`GSH_BHR_LEN-2:0], predict_cond};
+	 end
+	 if (we & mpft_valid[3]) begin
+	    bhr3 <= {bhr3[`GSH_BHR_LEN-2:0], predict_cond};
+	 end
+	 if (we & mpft_valid[4]) begin
+	    bhr4 <= {bhr4[`GSH_BHR_LEN-2:0], predict_cond};
+	 end
+	 if (we) begin
+	    bhr_master <= {bhr_master[`GSH_BHR_LEN-2:0], predict_cond};
+	 end
+      end
+   end
+   
+   assign predict_cond = (hit_bht && (rif > 2'b01)) ? 1'b1 : 1'b0;
+   assign wex_calc = {1'b0, rex} + (wcond ? 3'b001 : 3'b111);
+   assign wex = ((rex == 2'b00) && ~wcond) ? 2'b00 :
+		((rex == 2'b11) && wcond) ? 2'b11 : wex_calc[1:0];
+
+   pht prhisttbl
+     (
+      .clk(clk),
+      .raddr_if(pc[2+:`GSH_BHR_LEN] ^ bhr_master),
+      .raddr_ex(went),
+      .waddr_ex(went),
+      .rdata_if(rif),
+      .rdata_ex(rex),
+      .wdata_ex(wex),
+      .we_ex(we)
+      );
+   
+
+endmodule // gshare_predictor
+
+module pht(
+	   input wire 			 clk,
+	   input wire [`GSH_PHT_SEL-1:0] raddr_if,
+	   input wire [`GSH_PHT_SEL-1:0] raddr_ex,
+	   input wire [`GSH_PHT_SEL-1:0] waddr_ex,
+	   output wire [1:0] 		 rdata_if,
+	   output wire [1:0] 		 rdata_ex,
+	   input wire [1:0] 		 wdata_ex,
+	   input wire 			 we_ex
+	   );
+   
+   true_dualport_ram #(`GSH_PHT_SEL, 2, `GSH_PHT_NUM) pht0
+     (
+      .clka(~clk),
+      .addra(raddr_if),
+      .rdataa(rdata_if),
+      .wdataa(),
+      .wea(1'b0),
+      .clkb(clk),
+      .addrb(waddr_ex),
+      .rdatab(),
+      .wdatab(wdata_ex),
+      .web(we_ex)
+      );
+   
+   true_dualport_ram #(`GSH_PHT_SEL, 2, `GSH_PHT_NUM) pht1
+     (
+      .clka(~clk),
+      .addra(raddr_ex),
+      .rdataa(rdata_ex),
+      .wdataa(),
+      .wea(1'b0),
+      .clkb(clk),
+      .addrb(waddr_ex),
+      .rdatab(),
+      .wdatab(wdata_ex),
+      .web(we_ex)
+      );
+   
+endmodule // pht
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/imem.v
+++ b/examples/SQED_ridecore/rtl/design/imem.v
@@ -1,0 +1,30 @@
+`include "constants.vh"
+`default_nettype none
+// 8KB Instruction Memory (32bit*4way)
+module imem(
+	    input wire 			 clk,
+	    input wire [8:0] 		 addr,
+	    output reg [`INSN_LEN*4-1:0] data
+	    );
+   reg [`INSN_LEN*4-1:0] 		 mem[0:511];
+   always @ (posedge clk) begin
+      data <= mem[addr];
+   end
+endmodule // imem
+
+module imem_ld(
+	       input wire 		    clk,
+	       input wire [8:0] 	    addr,
+	       output reg [4*`INSN_LEN-1:0] rdata,
+	       input wire [4*`INSN_LEN-1:0] wdata,
+	       input wire we
+	       );
+   reg [`INSN_LEN*4-1:0] 		 mem[0:511];
+   always @ (posedge clk) begin
+      rdata <= mem[addr];
+      if (we) begin
+	 mem[addr] <= wdata;
+      end
+   end
+endmodule
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/imem_outa.v
+++ b/examples/SQED_ridecore/rtl/design/imem_outa.v
@@ -1,0 +1,15 @@
+module imem_outa
+  (
+   input [27:0]       pc,
+   output reg [127:0] idata
+   );
+
+   always @ (*) begin
+      case(pc)
+	28'h0: idata = 128'h00202023001081130010202304100093;
+	28'h1: idata = 128'h0000000000000000ffdff06f00202423;
+	default: idata = 128'h0;
+      endcase // case (pc)
+   end
+endmodule // imem_outa
+

--- a/examples/SQED_ridecore/rtl/design/imm_gen.v
+++ b/examples/SQED_ridecore/rtl/design/imm_gen.v
@@ -1,0 +1,27 @@
+`include "constants.vh"
+`default_nettype none
+module imm_gen(
+               input wire [`INSN_LEN-1:0] 	inst,
+               input wire [`IMM_TYPE_WIDTH-1:0] imm_type,
+               output reg [`DATA_LEN-1:0] 	imm
+               );
+
+   always @(*) begin
+      case (imm_type)
+        // EDIT mutation: Incorrect bit selection of the immediate value
+        `IMM_I : imm = { {21{inst[31]}}, inst[30:25], inst[24:21], inst[20] };
+        //`IMM_I : imm = { {21{inst[31]}}, inst[30:25], inst[24:21], inst[7] };
+         // END EDIT 
+        `IMM_S : imm = { {21{inst[31]}}, inst[30:25], inst[11:8], inst[7] };
+        `IMM_U : imm = { inst[31], inst[30:20], inst[19:12], 12'b0 };
+        `IMM_J : imm = { {12{inst[31]}}, inst[19:12], inst[20], inst[30:25], inst[24:21], 1'b0 };
+        default : imm = { {21{inst[31]}}, inst[30:25], inst[24:21], inst[20] };
+      endcase // case (imm_type)
+   end
+
+endmodule // imm_gen
+
+
+
+
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/main.xdc
+++ b/examples/SQED_ridecore/rtl/design/main.xdc
@@ -1,0 +1,39 @@
+# UART
+set_property PACKAGE_PIN AU36 [get_ports TXD]
+set_property IOSTANDARD LVCMOS18 [get_ports TXD]
+set_property PACKAGE_PIN AU33 [get_ports RXD]
+set_property IOSTANDARD LVCMOS18 [get_ports RXD]
+
+# LED
+set_property PACKAGE_PIN AM39 [get_ports LED[0]]
+set_property IOSTANDARD LVCMOS18 [get_ports LED[0]]
+set_property PACKAGE_PIN AN39 [get_ports LED[1]]
+set_property IOSTANDARD LVCMOS18 [get_ports LED[1]]
+set_property PACKAGE_PIN AR37 [get_ports LED[2]]
+set_property IOSTANDARD LVCMOS18 [get_ports LED[2]]
+set_property PACKAGE_PIN AT37 [get_ports LED[3]]
+set_property IOSTANDARD LVCMOS18 [get_ports LED[3]]
+set_property PACKAGE_PIN AR35 [get_ports LED[4]]
+set_property IOSTANDARD LVCMOS18 [get_ports LED[4]]
+set_property PACKAGE_PIN AP41 [get_ports LED[5]]
+set_property IOSTANDARD LVCMOS18 [get_ports LED[5]]
+set_property PACKAGE_PIN AP42 [get_ports LED[6]]
+set_property IOSTANDARD LVCMOS18 [get_ports LED[6]]
+set_property PACKAGE_PIN AU39 [get_ports LED[7]]
+set_property IOSTANDARD LVCMOS18 [get_ports LED[7]]
+
+# CLK
+# PadFunction: IO_L12P_T1_MRCC_38 
+set_property VCCAUX_IO DONTCARE [get_ports {CLK_P}]
+set_property IOSTANDARD DIFF_SSTL15 [get_ports {CLK_P}]
+set_property PACKAGE_PIN E19 [get_ports {CLK_P}]
+
+# PadFunction: IO_L12N_T1_MRCC_38 
+set_property VCCAUX_IO DONTCARE [get_ports {CLK_N}]
+set_property IOSTANDARD DIFF_SSTL15 [get_ports {CLK_N}]
+set_property PACKAGE_PIN E18 [get_ports {CLK_N}]
+
+# PadFunction: IO_L13N_T2_MRCC_15 
+set_property VCCAUX_IO DONTCARE [get_ports {RST_X_IN}]
+set_property IOSTANDARD LVCMOS18 [get_ports {RST_X_IN}]
+set_property PACKAGE_PIN AW40 [get_ports {RST_X_IN}]

--- a/examples/SQED_ridecore/rtl/design/mpft.v
+++ b/examples/SQED_ridecore/rtl/design/mpft.v
@@ -1,0 +1,151 @@
+`include "constants.vh"
+`default_nettype none
+module tag_decoder
+  (
+   input wire [`SPECTAG_LEN-1:0] in,
+   output reg [2:0] 		 out
+   );
+
+   always @ (*) begin
+      out = 0;
+      case (in)
+	5'b00001: out = 0;
+	5'b00010: out = 1;
+	5'b00100: out = 2;
+	5'b01000: out = 3;
+	5'b10000: out = 4;
+	default: out = 0;
+      endcase // case (in)
+   end
+endmodule // tag_decoder
+
+module miss_prediction_fix_table
+  (
+   input wire 			  clk,
+   input wire 			  reset,
+   output reg [`SPECTAG_LEN-1:0]  mpft_valid,
+   input wire [`SPECTAG_LEN-1:0]  value_addr,
+   output wire [`SPECTAG_LEN-1:0] mpft_value,
+   input wire 			  prmiss,
+   input wire 			  prsuccess,
+   input wire [`SPECTAG_LEN-1:0]  prsuccess_tag,
+   input wire [`SPECTAG_LEN-1:0]  setspec1_tag, //inst1_spectag
+   input wire 			  setspec1_en, //inst1_isbranch & ~inst1_inv
+   input wire [`SPECTAG_LEN-1:0]  setspec2_tag,
+   input wire 			  setspec2_en
+   );
+
+   reg [`SPECTAG_LEN-1:0] 	  value0;
+   reg [`SPECTAG_LEN-1:0] 	  value1;
+   reg [`SPECTAG_LEN-1:0] 	  value2;
+   reg [`SPECTAG_LEN-1:0] 	  value3;
+   reg [`SPECTAG_LEN-1:0] 	  value4;
+
+   wire [2:0] 			  val_idx;
+   
+   tag_decoder td(
+		  .in(value_addr),
+		  .out(val_idx)
+		  );
+   
+   
+   assign mpft_value = {
+			value4[val_idx],
+			value3[val_idx],
+			value2[val_idx],
+			value1[val_idx],
+			value0[val_idx]
+			};
+
+   /*
+    wire [`SPECTAG_LEN-1:0] value0_wdec =
+    (~setspec1_tag[0] || ~setspec1_en ? 5'b0 :
+    (setspec1_tag |
+    ((setspec1_tag == 5'b00001) ? mpft_valid : 5'b0))) |
+    (~setspec2_tag[0] || ~setspec2_en ? 5'b0 :
+    (setspec2_tag |
+    ((setspec2_tag == 5'b00001) ? mpft_valid : 5'b0)));
+    */
+   wire [`SPECTAG_LEN-1:0] 	  wdecdata = mpft_valid | (setspec1_en ? setspec1_tag : 0);
+
+   wire [`SPECTAG_LEN-1:0] 	  value0_wdec =
+				  (~setspec1_tag[0] || ~setspec1_en ? 5'b0 :
+				   (setspec1_tag | 
+				    ((setspec1_tag == 5'b00001) ? mpft_valid : 5'b0))) |
+				  (~setspec2_tag[0] || ~setspec2_en ? 5'b0 :
+				   (setspec2_tag |
+				    ((setspec2_tag == 5'b00001) ? wdecdata : 5'b0)));
+   
+   wire [`SPECTAG_LEN-1:0] 	  value1_wdec =
+				  (~setspec1_tag[1] || ~setspec1_en ? 5'b0 :
+				   (setspec1_tag |
+				    ((setspec1_tag == 5'b00010) ? mpft_valid : 5'b0))) |
+				  (~setspec2_tag[1] || ~setspec2_en ? 5'b0 :
+				   (setspec2_tag |
+				    ((setspec2_tag == 5'b00010) ? wdecdata : 5'b0)));
+   
+   wire [`SPECTAG_LEN-1:0] 	  value2_wdec =
+				  (~setspec1_tag[2] || ~setspec1_en ? 5'b0 :
+				   (setspec1_tag |
+				    ((setspec1_tag == 5'b00100) ? mpft_valid : 5'b0))) |
+				  (~setspec2_tag[2] || ~setspec2_en ? 5'b0 :
+				   (setspec2_tag |
+				    ((setspec2_tag == 5'b00100) ? wdecdata : 5'b0)));
+   
+   wire [`SPECTAG_LEN-1:0] 	  value3_wdec =
+				  (~setspec1_tag[3] || ~setspec1_en ? 5'b0 :
+				   (setspec1_tag |
+				    ((setspec1_tag == 5'b01000) ? mpft_valid : 5'b0))) |
+				  (~setspec2_tag[3] || ~setspec2_en ? 5'b0 :
+				   (setspec2_tag |
+				    ((setspec2_tag == 5'b01000) ? wdecdata : 5'b0)));
+   
+   wire [`SPECTAG_LEN-1:0] 	  value4_wdec =
+				  (~setspec1_tag[4] || ~setspec1_en ? 5'b0 :
+				   (setspec1_tag |
+				    ((setspec1_tag == 5'b10000) ? mpft_valid : 5'b0))) |
+				  (~setspec2_tag[4] || ~setspec2_en ? 5'b0 :
+				   (setspec2_tag |
+				    ((setspec2_tag == 5'b10000) ? wdecdata : 5'b0)));
+   
+   wire [`SPECTAG_LEN-1:0] 	  value0_wprs =
+				  (prsuccess_tag[0] ? 5'b0 : ~prsuccess_tag);
+   wire [`SPECTAG_LEN-1:0] 	  value1_wprs =
+				  (prsuccess_tag[1] ? 5'b0 : ~prsuccess_tag);
+   wire [`SPECTAG_LEN-1:0] 	  value2_wprs =
+				  (prsuccess_tag[2] ? 5'b0 : ~prsuccess_tag);
+   wire [`SPECTAG_LEN-1:0] 	  value3_wprs =
+				  (prsuccess_tag[3] ? 5'b0 : ~prsuccess_tag);
+   wire [`SPECTAG_LEN-1:0] 	  value4_wprs =
+				  (prsuccess_tag[4] ? 5'b0 : ~prsuccess_tag);
+   
+   always @ (posedge clk) begin
+      if (reset | prmiss) begin
+	 mpft_valid <= 0;
+      end else if (prsuccess) begin
+	 mpft_valid <= mpft_valid & ~prsuccess_tag;
+      end else begin
+	 mpft_valid <= mpft_valid | 
+		       (setspec1_en ? setspec1_tag : 0) |
+		       (setspec2_en ? setspec2_tag : 0);
+      end
+   end
+
+   always @ (posedge clk) begin
+      if (reset | prmiss) begin
+	 value0 <= 0;
+	 value1 <= 0;
+	 value2 <= 0;
+	 value3 <= 0;
+	 value4 <= 0;
+      end else begin
+	 value0 <= prsuccess ? (value0 & value0_wprs) : (value0 | value0_wdec);
+	 value1 <= prsuccess ? (value1 & value1_wprs) : (value1 | value1_wdec);
+	 value2 <= prsuccess ? (value2 & value2_wprs) : (value2 | value2_wdec);
+	 value3 <= prsuccess ? (value3 & value3_wprs) : (value3 | value3_wdec);
+	 value4 <= prsuccess ? (value4 & value4_wprs) : (value4 | value4_wdec);
+      end
+   end
+   
+endmodule // miss_prediction_fix_table
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/multiplier.v
+++ b/examples/SQED_ridecore/rtl/design/multiplier.v
@@ -1,0 +1,65 @@
+`include "constants.vh"
+`include "rv32_opcodes.vh"
+`include "alu_ops.vh"
+`default_nettype none
+module mux_4x1(
+	       input wire [1:0] 	    sel,
+	       input wire [2*`DATA_LEN-1:0] dat0,
+	       input wire [2*`DATA_LEN-1:0] dat1,
+	       input wire [2*`DATA_LEN-1:0] dat2,
+	       input wire [2*`DATA_LEN-1:0] dat3,
+	       output reg [2*`DATA_LEN-1:0] out
+	       );
+   always @(*) begin
+      case(sel)
+	0: begin
+	   out = dat0;
+	end
+	1: begin
+	   out = dat1;
+	end
+	2: begin
+	   out = dat2;
+	end
+	3: begin
+	   out = dat3;
+	end
+      endcase
+   end
+endmodule // mux_4x1
+
+// sel_lohi = md_req_out_sel[0]
+module multiplier(
+		  input wire signed [`DATA_LEN-1:0] src1,
+		  input wire signed [`DATA_LEN-1:0] src2,
+		  input wire 			    src1_signed,
+		  input wire 			    src2_signed,
+		  input wire 			    sel_lohi,
+		  output wire [`DATA_LEN-1:0] 	    result
+		  );
+
+   wire signed [`DATA_LEN:0] 			    src1_unsign = {1'b0, src1};
+   wire signed [`DATA_LEN:0] 			    src2_unsign = {1'b0, src2};
+
+   wire signed [2*`DATA_LEN-1:0] 		    res_ss = src1 * src2;
+   wire signed [2*`DATA_LEN-1:0] 		    res_su = src1 * src2_unsign;
+   wire signed [2*`DATA_LEN-1:0] 		    res_us = src1_unsign * src2;
+   wire signed [2*`DATA_LEN-1:0] 		    res_uu = src1_unsign * src2_unsign;
+
+   wire [2*`DATA_LEN-1:0] 			    res;
+
+   mux_4x1 mxres(
+		 .sel({src1_signed, src2_signed}),
+		 .dat0(res_uu),
+		 .dat1(res_us),
+		 .dat2(res_su),
+		 .dat3(res_ss),
+		 .out(res)
+		 );
+   
+   assign result = sel_lohi ? res[`DATA_LEN+:`DATA_LEN] : res[`DATA_LEN-1:0];
+   
+endmodule // multiplier
+
+
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/oldest_finder.v
+++ b/examples/SQED_ridecore/rtl/design/oldest_finder.v
@@ -1,0 +1,115 @@
+`default_nettype none
+
+module oldest_finder2 #(
+			parameter ENTLEN = 1,
+			parameter VALLEN = 8
+			)
+  (
+   input wire [2*ENTLEN-1:0] entvec,
+   input wire [2*VALLEN-1:0] valvec,
+   output wire [ENTLEN-1:0]  oldent,
+   output wire [VALLEN-1:0]  oldval
+   );
+   //VALLEN = RRF_SEL+sortbit+~rdy
+   
+   wire [ENTLEN-1:0] 	     ent1 = entvec[0+:ENTLEN];
+   wire [ENTLEN-1:0] 	     ent2 = entvec[ENTLEN+:ENTLEN];
+   wire [VALLEN-1:0] 	     val1 = valvec[0+:VALLEN];
+   wire [VALLEN-1:0] 	     val2 = valvec[VALLEN+:VALLEN];
+
+   assign oldent = (val1 < val2) ? ent1 : ent2;
+   assign oldval = (val1 < val2) ? val1 : val2;
+
+endmodule // oldest_finder2
+
+module oldest_finder4 #(
+			parameter ENTLEN = 2,
+			parameter VALLEN = 8
+			)
+   (
+    input wire [4*ENTLEN-1:0] entvec,
+    input wire [4*VALLEN-1:0] valvec,
+    output wire [ENTLEN-1:0]  oldent,
+    output wire [VALLEN-1:0]  oldval
+   );
+   //VALLEN = RRF_SEL+sortbit+~rdy
+
+   wire [ENTLEN-1:0] 	     oldent1;
+   wire [ENTLEN-1:0] 	     oldent2;
+   wire [VALLEN-1:0] 	     oldval1;
+   wire [VALLEN-1:0] 	     oldval2;
+
+   oldest_finder2 #(ENTLEN, VALLEN) of2_1
+     (
+      .entvec({entvec[ENTLEN+:ENTLEN], entvec[0+:ENTLEN]}),
+      .valvec({valvec[VALLEN+:VALLEN], valvec[0+:VALLEN]}),
+      .oldent(oldent1),
+      .oldval(oldval1)
+      );
+
+   oldest_finder2 #(ENTLEN, VALLEN) of2_2
+     (
+      .entvec({entvec[3*ENTLEN+:ENTLEN], entvec[2*ENTLEN+:ENTLEN]}),
+      .valvec({valvec[3*VALLEN+:VALLEN], valvec[2*VALLEN+:VALLEN]}),
+      .oldent(oldent2),
+      .oldval(oldval2)
+      );
+
+   oldest_finder2 #(ENTLEN, VALLEN) ofmas
+     (
+      .entvec({oldent2, oldent1}),
+      .valvec({oldval2, oldval1}),
+      .oldent(oldent),
+      .oldval(oldval)
+      );
+   
+endmodule // oldest_finder4
+
+module oldest_finder8 #(
+			parameter ENTLEN = 3,
+			parameter VALLEN = 8
+			)
+   (
+    input wire [8*ENTLEN-1:0] entvec,
+    input wire [8*VALLEN-1:0] valvec,
+    output wire [ENTLEN-1:0]  oldent,
+    output wire [VALLEN-1:0]  oldval
+   );
+   //VALLEN = RRF_SEL+sortbit+~rdy
+
+   wire [ENTLEN-1:0] 	     oldent1;
+   wire [ENTLEN-1:0] 	     oldent2;
+   wire [VALLEN-1:0] 	     oldval1;
+   wire [VALLEN-1:0] 	     oldval2;
+   
+   oldest_finder4 #(ENTLEN, VALLEN) of4_1
+     (
+      .entvec({entvec[3*ENTLEN+:ENTLEN], entvec[2*ENTLEN+:ENTLEN],
+	       entvec[ENTLEN+:ENTLEN], entvec[0+:ENTLEN]}),
+      .valvec({valvec[3*VALLEN+:VALLEN], valvec[2*VALLEN+:VALLEN],
+	       valvec[VALLEN+:VALLEN], valvec[0+:VALLEN]}),
+      .oldent(oldent1),
+      .oldval(oldval1)
+      );
+
+   oldest_finder4 #(ENTLEN, VALLEN) of4_2
+     (
+      .entvec({entvec[7*ENTLEN+:ENTLEN], entvec[6*ENTLEN+:ENTLEN],
+	       entvec[5*ENTLEN+:ENTLEN], entvec[4*ENTLEN+:ENTLEN]}),
+      .valvec({valvec[7*VALLEN+:VALLEN], valvec[6*VALLEN+:VALLEN],
+	       valvec[5*VALLEN+:VALLEN], valvec[4*VALLEN+:VALLEN]}),
+      .oldent(oldent2),
+      .oldval(oldval2)
+      );
+
+   oldest_finder2 #(ENTLEN, VALLEN) ofmas
+     (
+      .entvec({oldent2, oldent1}),
+      .valvec({oldval2, oldval1}),
+      .oldent(oldent),
+      .oldval(oldval)
+      );
+   
+endmodule // oldest_finder8
+
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/pipeline.v
+++ b/examples/SQED_ridecore/rtl/design/pipeline.v
@@ -1,0 +1,2034 @@
+`include "constants.vh"
+`include "alu_ops.vh"
+`include "rv32_opcodes.vh"
+
+`default_nettype none
+
+module pipeline
+  (
+   // EDIT: QED instruction is now an input
+   input wire [`INSN_LEN-1:0] qed_instruction,
+   input wire qed_vld_out,
+   // EDIT: END
+   input wire 			clk,
+   input wire 			reset,
+   output reg [`ADDR_LEN-1:0] 	pc,
+   input wire [4*`INSN_LEN-1:0] idata,
+   output wire [`DATA_LEN-1:0] 	dmem_wdata,
+   output wire 			dmem_we,
+   output wire [`ADDR_LEN-1:0] 	dmem_addr,
+   input wire [`DATA_LEN-1:0] 	dmem_data,
+
+   // EDIT
+   output wire [`DATA_LEN-1:0] gpr0_o,
+   output wire [`DATA_LEN-1:0] gpr1_o,
+   output wire [`DATA_LEN-1:0] gpr2_o,
+   output wire [`DATA_LEN-1:0] gpr3_o,
+   output wire [`DATA_LEN-1:0] gpr4_o,
+   output wire [`DATA_LEN-1:0] gpr5_o,
+   output wire [`DATA_LEN-1:0] gpr6_o,
+   output wire [`DATA_LEN-1:0] gpr7_o,
+   output wire [`DATA_LEN-1:0] gpr8_o,
+   output wire [`DATA_LEN-1:0] gpr9_o,
+   output wire [`DATA_LEN-1:0] gpr10_o,
+   output wire [`DATA_LEN-1:0] gpr11_o,
+   output wire [`DATA_LEN-1:0] gpr12_o,
+   output wire [`DATA_LEN-1:0] gpr13_o,
+   output wire [`DATA_LEN-1:0] gpr14_o,
+   output wire [`DATA_LEN-1:0] gpr15_o,
+   output wire [`DATA_LEN-1:0] gpr16_o,
+   output wire [`DATA_LEN-1:0] gpr17_o,
+   output wire [`DATA_LEN-1:0] gpr18_o,
+   output wire [`DATA_LEN-1:0] gpr19_o,
+   output wire [`DATA_LEN-1:0] gpr20_o,
+   output wire [`DATA_LEN-1:0] gpr21_o,
+   output wire [`DATA_LEN-1:0] gpr22_o,
+   output wire [`DATA_LEN-1:0] gpr23_o,
+   output wire [`DATA_LEN-1:0] gpr24_o,
+   output wire [`DATA_LEN-1:0] gpr25_o,
+   output wire [`DATA_LEN-1:0] gpr26_o,
+   output wire [`DATA_LEN-1:0] gpr27_o,
+   output wire [`DATA_LEN-1:0] gpr28_o,
+   output wire [`DATA_LEN-1:0] gpr29_o,
+   output wire [`DATA_LEN-1:0] gpr30_o,
+   output wire [`DATA_LEN-1:0] gpr31_o,
+   output wire arfwe1_o,
+   output wire arfwe2_o,
+   output wire [`REG_SEL-1:0] dstarf1_o,
+   output wire [`REG_SEL-1:0] dstarf2_o,
+   output wire stall_IF_o
+   // EDIT: END
+   );
+   
+   
+   // EDIT
+   assign arfwe1_o = arfwe1;
+   assign arfwe2_o = arfwe2;
+   assign dstarf1_o = dstarf1;
+   assign dstarf2_o = dstarf2;
+   assign stall_IF_o = stall_IF;
+   // EDIT: END
+
+   wire  stall_IF;
+   wire  kill_IF;
+   wire  stall_ID;
+   wire  kill_ID;
+   wire  stall_DP;
+   wire  kill_DP;
+//   reg [`ADDR_LEN-1:0] pc;
+
+   //IF
+   // Signal from pipe_if
+   wire     	       prcond;
+   wire [`ADDR_LEN-1:0] npc;
+   // EDIT: make inst1 an input
+   // wire [`INSN_LEN-1:0] inst1;
+   // EDIT: END
+   wire [`INSN_LEN-1:0] inst2;
+   wire 		invalid2_pipe;
+   wire [`GSH_BHR_LEN-1:0] bhr;
+   
+   //Instruction Buffer
+   reg 			   prcond_if;
+   reg [`ADDR_LEN-1:0] 	   npc_if;
+   reg [`ADDR_LEN-1:0] 	   pc_if;
+   reg [`INSN_LEN-1:0] 	   inst1_if;
+   reg [`INSN_LEN-1:0] 	   inst2_if;
+   reg 			   inv1_if;
+   reg 			   inv2_if;
+   reg 			   bhr_if;
+   wire 		   attachable;
+
+   //ID
+   //Decode Info1
+   wire [`IMM_TYPE_WIDTH-1:0] imm_type_1;
+   wire [`REG_SEL-1:0] 	      rs1_1;
+   wire [`REG_SEL-1:0] 	      rs2_1;
+   wire [`REG_SEL-1:0] 	      rd_1;
+   wire [`SRC_A_SEL_WIDTH-1:0] src_a_sel_1;
+   wire [`SRC_B_SEL_WIDTH-1:0] src_b_sel_1;
+   wire 		       wr_reg_1;
+   wire 		       uses_rs1_1;
+   wire 		       uses_rs2_1;
+   wire 		       illegal_instruction_1;
+   wire [`ALU_OP_WIDTH-1:0]    alu_op_1;
+   wire [`RS_ENT_SEL-1:0]      rs_ent_1;
+   wire [2:0] 		       dmem_size_1;
+   wire [`MEM_TYPE_WIDTH-1:0]  dmem_type_1;			  
+   wire [`MD_OP_WIDTH-1:0]     md_req_op_1;
+   wire 		       md_req_in_1_signed_1;
+   wire 		       md_req_in_2_signed_1;
+   wire [`MD_OUT_SEL_WIDTH-1:0] md_req_out_sel_1;
+   //Decode Info2
+   wire [`IMM_TYPE_WIDTH-1:0] 	imm_type_2;
+   wire [`REG_SEL-1:0] 		rs1_2;
+   wire [`REG_SEL-1:0] 		rs2_2;
+   wire [`REG_SEL-1:0] 		rd_2;
+   wire [`SRC_A_SEL_WIDTH-1:0] 	src_a_sel_2;
+   wire [`SRC_B_SEL_WIDTH-1:0] 	src_b_sel_2;
+   wire 			wr_reg_2;
+   wire 			uses_rs1_2;
+   wire 			uses_rs2_2;
+   wire 			illegal_instruction_2;
+   wire [`ALU_OP_WIDTH-1:0] 	alu_op_2;
+   wire [`RS_ENT_SEL-1:0] 	rs_ent_2;
+   wire [2:0] 			dmem_size_2;
+   wire [`MEM_TYPE_WIDTH-1:0] 	dmem_type_2;			  
+   wire [`MD_OP_WIDTH-1:0] 	md_req_op_2;
+   wire 			md_req_in_1_signed_2;
+   wire 			md_req_in_2_signed_2;
+   wire [`MD_OUT_SEL_WIDTH-1:0] md_req_out_sel_2;
+   //Additional Info
+   wire [`SPECTAG_LEN-1:0] 	sptag1;
+   wire [`SPECTAG_LEN-1:0] 	sptag2;
+   wire [`SPECTAG_LEN-1:0] 	tagreg;
+   wire 			spec1;
+   wire 			spec2;
+   wire 			isbranch1;
+   wire 			isbranch2;
+   wire 			branchvalid1;
+   wire 			branchvalid2;
+   
+   //Latch
+   //Decode Info1
+   reg [`IMM_TYPE_WIDTH-1:0] 	imm_type_1_id;
+   reg [`REG_SEL-1:0] 		rs1_1_id;
+   reg [`REG_SEL-1:0] 		rs2_1_id;
+   reg [`REG_SEL-1:0] 		rd_1_id;
+   reg [`SRC_A_SEL_WIDTH-1:0] 	src_a_sel_1_id;
+   reg [`SRC_B_SEL_WIDTH-1:0] 	src_b_sel_1_id;
+   reg 				wr_reg_1_id;
+   reg 				uses_rs1_1_id;
+   reg 				uses_rs2_1_id;
+   reg 				illegal_instruction_1_id;
+   reg [`ALU_OP_WIDTH-1:0] 	alu_op_1_id;
+   reg [`RS_ENT_SEL-1:0] 	rs_ent_1_id;
+   reg [2:0] 			dmem_size_1_id;
+   reg [`MEM_TYPE_WIDTH-1:0] 	dmem_type_1_id;			  
+   reg [`MD_OP_WIDTH-1:0] 	md_req_op_1_id;
+   reg 				md_req_in_1_signed_1_id;
+   reg 				md_req_in_2_signed_1_id;
+   reg [`MD_OUT_SEL_WIDTH-1:0] 	md_req_out_sel_1_id;
+   //Decode Info2
+   reg [`IMM_TYPE_WIDTH-1:0] 	imm_type_2_id;
+   reg [`REG_SEL-1:0] 		rs1_2_id;
+   reg [`REG_SEL-1:0] 		rs2_2_id;
+   reg [`REG_SEL-1:0] 		rd_2_id;
+   reg [`SRC_A_SEL_WIDTH-1:0] 	src_a_sel_2_id;
+   reg [`SRC_B_SEL_WIDTH-1:0] 	src_b_sel_2_id;
+   reg 				wr_reg_2_id;
+   reg 				uses_rs1_2_id;
+   reg 				uses_rs2_2_id;
+   reg 				illegal_instruction_2_id;
+   reg [`ALU_OP_WIDTH-1:0] 	alu_op_2_id;
+   reg [`RS_ENT_SEL-1:0] 	rs_ent_2_id;
+   reg [2:0] 			dmem_size_2_id;
+   reg [`MEM_TYPE_WIDTH-1:0] 	dmem_type_2_id;			  
+   reg [`MD_OP_WIDTH-1:0] 	md_req_op_2_id;
+   reg 				md_req_in_1_signed_2_id;
+   reg 				md_req_in_2_signed_2_id;
+   reg [`MD_OUT_SEL_WIDTH-1:0] 	md_req_out_sel_2_id;
+   //Additional Info
+   reg 				rs1_2_eq_dst1_id;
+   reg 				rs2_2_eq_dst1_id;
+   reg [`SPECTAG_LEN-1:0] 	sptag1_id;
+   reg [`SPECTAG_LEN-1:0] 	sptag2_id;
+   reg [`SPECTAG_LEN-1:0] 	tagreg_id;
+   reg 				spec1_id;
+   reg 				spec2_id;
+   reg [`INSN_LEN-1:0] 		inst1_id;
+   reg [`INSN_LEN-1:0] 		inst2_id;
+   reg 				prcond1_id;
+   reg 				prcond2_id;
+   reg 				inv1_id;
+   reg 				inv2_id;
+   reg [`ADDR_LEN-1:0] 		praddr1_id;
+   reg [`ADDR_LEN-1:0] 		praddr2_id;
+   reg [`ADDR_LEN-1:0] 		pc_id;
+   reg [`GSH_BHR_LEN-1:0] 	bhr_id;
+   reg 				isbranch1_id;
+   reg 				isbranch2_id;
+
+   //DP
+   //Source Operand Manager wire
+   wire [`DATA_LEN-1:0] opr1_1;
+   wire [`DATA_LEN-1:0] opr2_1;
+   wire [`DATA_LEN-1:0] opr1_2;
+   wire [`DATA_LEN-1:0] opr2_2;
+   wire 		rdy1_1;
+   wire 		rdy2_1;
+   wire 		rdy1_2;
+   wire 		rdy2_2;
+
+   //rrf_FL wire
+   wire 		alloc_rrf;
+   wire [`RRF_SEL-1:0] 	dst1_renamed;
+   wire [`RRF_SEL-1:0] 	dst2_renamed;
+   wire [`RRF_SEL:0] 	freenum;
+   wire [`RRF_SEL-1:0] 	rrfptr;
+   wire [`RRF_SEL-1:0] 	rrftagfix;
+
+   //arf wire 
+   wire [`RRF_SEL-1:0] 	rs1_1tag;
+   wire [`RRF_SEL-1:0] 	rs2_1tag;
+   wire [`RRF_SEL-1:0] 	rs1_2tag;
+   wire [`RRF_SEL-1:0] 	rs2_2tag;
+   wire [`DATA_LEN-1:0] adat1_1;
+   wire [`DATA_LEN-1:0] adat2_1;
+   wire [`DATA_LEN-1:0] adat1_2;
+   wire [`DATA_LEN-1:0] adat2_2;
+   wire 		abusy1_1;
+   wire 		abusy2_1;
+   wire 		abusy1_2;
+   wire 		abusy2_2;
+
+   //rrf wire
+   wire [`DATA_LEN-1:0] rdat1_1;
+   wire [`DATA_LEN-1:0] rdat2_1;
+   wire [`DATA_LEN-1:0] rdat1_2;
+   wire [`DATA_LEN-1:0] rdat2_2;
+   wire 		rvalid1_1;
+   wire 		rvalid2_1;
+   wire 		rvalid1_2;
+   wire 		rvalid2_2;
+   wire [`DATA_LEN-1:0] com1data;
+   wire [`DATA_LEN-1:0] com2data;
+   
+   //Src Manager wire
+   wire [`DATA_LEN-1:0] src1_1; //To reservation station
+   wire [`DATA_LEN-1:0] src2_1; 
+   wire [`DATA_LEN-1:0] src1_2;
+   wire [`DATA_LEN-1:0] src2_2;
+   wire 		resolved1_1;
+   wire 		resolved2_1;
+   wire 		resolved1_2;
+   wire 		resolved2_2;
+
+   //Immgen wire
+   wire [`DATA_LEN-1:0] imm1; // To reservation station
+   wire [`DATA_LEN-1:0] imm2;
+   //BrImmgen wire
+   wire [`DATA_LEN-1:0] brimm1; //To reservation station
+   wire [`DATA_LEN-1:0] brimm2;
+   
+   //RS Request Generator wire
+   wire 		req1_alu;
+   wire 		req2_alu;
+   wire [1:0] 		req_alunum;
+   wire 		req1_branch;
+   wire 		req2_branch;
+   wire [1:0] 		req_branchnum;
+   wire 		req1_mul;
+   wire 		req2_mul;
+   wire [1:0] 		req_mulnum;
+   wire 		req1_ldst;
+   wire 		req2_ldst;
+   wire [1:0] 		req_ldstnum;
+
+   wire [`ALU_ENT_SEL:0] allocent1_alu;
+   wire [`ALU_ENT_SEL:0] allocent2_alu;
+   wire 		 rsalu1_we1;
+   wire 		 rsalu1_we2;
+   wire 		 rsalu2_we1;
+   wire 		 rsalu2_we2;
+   wire [`ALU_ENT_NUM-1:0] busyvec_alu1;
+   wire [`ALU_ENT_NUM-1:0] busyvec_alu2;
+   wire [2*`ALU_ENT_NUM-1:0] busyvec_alu;
+   wire [`ALU_ENT_NUM:0]     ready_alu;
+
+   wire 		   issuevalid_alu1;
+   wire [`ALU_ENT_SEL-1:0] issueent_alu1;
+   wire 		   issue_alu1;
+   wire 		   issuevalid_alu2;
+   wire [`ALU_ENT_SEL-1:0] issueent_alu2;
+   wire 		   issue_alu2;
+   wire 		   allocatable_alu;
+   wire [`ALU_ENT_NUM*(`RRF_SEL+2)-1:0] histvect1;
+   wire [`ALU_ENT_NUM*(`RRF_SEL+2)-1:0] histvect2;
+   wire [`RRF_SEL+1:0] 			entval_alu1;
+   wire [`RRF_SEL+1:0] 			entval_alu2;
+   
+   wire 				nextrrfcyc;
+
+   wire [`DATA_LEN-1:0]    ex_src1_alu1;
+   wire [`DATA_LEN-1:0]    ex_src2_alu1;
+   wire [`ALU_ENT_NUM-1:0] ready_alu1;
+   wire [`ADDR_LEN-1:0]    pc_alu1;
+   wire [`DATA_LEN-1:0]    imm_alu1;
+   wire [`RRF_SEL-1:0] 	   rrftag_alu1;
+   wire 		   dstval_alu1;
+   wire [`SRC_A_SEL_WIDTH-1:0] src_a_alu1;
+   wire [`SRC_B_SEL_WIDTH-1:0] src_b_alu1;
+   wire [`ALU_OP_WIDTH-1:0]    alu_op_alu1;
+   wire [`SPECTAG_LEN-1:0]     spectag_alu1;
+   wire 		       specbit_alu1;
+
+   wire [`DATA_LEN-1:0]        ex_src1_alu2;
+   wire [`DATA_LEN-1:0]        ex_src2_alu2;
+   wire [`ALU_ENT_NUM-1:0]     ready_alu2;
+   wire [`ADDR_LEN-1:0]        pc_alu2;
+   wire [`DATA_LEN-1:0]        imm_alu2;
+   wire [`RRF_SEL-1:0] 	       rrftag_alu2;
+   wire 		       dstval_alu2;
+   wire [`SRC_A_SEL_WIDTH-1:0] src_a_alu2;
+   wire [`SRC_B_SEL_WIDTH-1:0] src_b_alu2;
+   wire [`ALU_OP_WIDTH-1:0]    alu_op_alu2;
+   wire [`SPECTAG_LEN-1:0]     spectag_alu2;
+   wire 		       specbit_alu2;
+   
+   wire [`LDST_ENT_SEL-1:0]    allocent1_ldst;
+   wire [`LDST_ENT_SEL-1:0]    allocent2_ldst;
+   wire [`LDST_ENT_NUM-1:0]    busyvec_ldst;
+   wire [`LDST_ENT_NUM-1:0]    prbusyvec_next_ldst;
+   wire [`LDST_ENT_NUM-1:0]    ready_ldst;
+   wire 		       issuevalid_ldst;
+   wire [`LDST_ENT_SEL-1:0]    issueent_ldst;
+   wire 		       issue_ldst;
+   wire 		       allocatable_ldst;
+
+   wire [`DATA_LEN-1:0]        ex_src1_ldst;
+   wire [`DATA_LEN-1:0]        ex_src2_ldst;
+   wire [`ADDR_LEN-1:0]        pc_ldst;
+   wire [`DATA_LEN-1:0]        imm_ldst;
+   wire [`RRF_SEL-1:0] 	       rrftag_ldst;
+   wire 		       dstval_ldst;
+   wire [`SPECTAG_LEN-1:0]     spectag_ldst;
+   wire 		       specbit_ldst;
+
+   wire [`BRANCH_ENT_SEL-1:0]  allocent1_branch;
+   wire [`BRANCH_ENT_SEL-1:0]  allocent2_branch;
+   wire [`BRANCH_ENT_NUM-1:0]  busyvec_branch;
+   wire [`BRANCH_ENT_NUM-1:0]  prbusyvec_next_branch;
+   wire [`BRANCH_ENT_NUM-1:0]  ready_branch;
+   wire 		       issuevalid_branch;
+   wire [`BRANCH_ENT_SEL-1:0]  issueent_branch;
+   wire 		       issue_branch;
+   wire 		       allocatable_branch;
+
+   wire [`DATA_LEN-1:0]        ex_src1_branch;
+   wire [`DATA_LEN-1:0]        ex_src2_branch;
+   wire [`ADDR_LEN-1:0]        pc_branch;
+   wire [`DATA_LEN-1:0]        imm_branch;
+   wire [`RRF_SEL-1:0] 	       rrftag_branch;
+   wire 		       dstval_branch;
+   wire [`ALU_OP_WIDTH-1:0]    alu_op_branch;
+   wire [`SPECTAG_LEN-1:0]     spectag_branch;
+   wire 		       specbit_branch;
+   wire [`GSH_BHR_LEN-1:0]     bhr_branch;
+   wire 		       prcond_branch;
+   wire [`ADDR_LEN-1:0]        praddr_branch;
+   wire [6:0] 		       opcode_branch;
+
+   wire [`MUL_ENT_SEL-1:0]       allocent1_mul;
+   wire [`MUL_ENT_SEL-1:0]       allocent2_mul;
+   wire [`MUL_ENT_NUM-1:0]     busyvec_mul;
+   wire [`MUL_ENT_NUM-1:0]     ready_mul;
+   wire 		       issuevalid_mul;
+   wire [`MUL_ENT_SEL-1:0]     issueent_mul;
+   wire 		       issue_mul;
+   wire 		       allocatable_mul;
+
+   wire [`DATA_LEN-1:0]        ex_src1_mul;
+   wire [`DATA_LEN-1:0]        ex_src2_mul;
+   wire [`ADDR_LEN-1:0]        pc_mul;
+   wire [`RRF_SEL-1:0] 	       rrftag_mul;
+   wire 		       dstval_mul;
+   wire [`SPECTAG_LEN-1:0]     spectag_mul;
+   wire 		       specbit_mul;
+   wire 		       src1_signed_mul;
+   wire 		       src2_signed_mul;
+   wire 		       sel_lohi_mul;
+
+   //EX
+   //ALU1
+   wire [`DATA_LEN-1:0]        result_alu1;
+   wire 		       rrfwe_alu1;
+   wire 		       robwe_alu1;
+   wire 		       kill_speculative_alu1;
+
+   reg [`DATA_LEN-1:0] 	       buf_ex_src1_alu1;
+   reg [`DATA_LEN-1:0] 	       buf_ex_src2_alu1;
+   reg [`ADDR_LEN-1:0] 	       buf_pc_alu1;
+   reg [`DATA_LEN-1:0] 	       buf_imm_alu1;
+   reg [`RRF_SEL-1:0] 	       buf_rrftag_alu1;
+   reg 			       buf_dstval_alu1;
+   reg [`SRC_A_SEL_WIDTH-1:0]  buf_src_a_alu1;
+   reg [`SRC_B_SEL_WIDTH-1:0]  buf_src_b_alu1;
+   reg [`ALU_OP_WIDTH-1:0]     buf_alu_op_alu1;
+   reg [`SPECTAG_LEN-1:0]      buf_spectag_alu1;
+   reg 			       buf_specbit_alu1;
+   //ALU2
+   wire [`DATA_LEN-1:0]        result_alu2;
+   wire 		       rrfwe_alu2;
+   wire 		       robwe_alu2;
+   wire 		       kill_speculative_alu2;
+
+   reg [`DATA_LEN-1:0] 	       buf_ex_src1_alu2;
+   reg [`DATA_LEN-1:0] 	       buf_ex_src2_alu2;
+   reg [`ADDR_LEN-1:0] 	       buf_pc_alu2;
+   reg [`DATA_LEN-1:0] 	       buf_imm_alu2;
+   reg [`RRF_SEL-1:0] 	       buf_rrftag_alu2;
+   reg 			       buf_dstval_alu2;
+   reg [`SRC_A_SEL_WIDTH-1:0]  buf_src_a_alu2;
+   reg [`SRC_B_SEL_WIDTH-1:0]  buf_src_b_alu2;
+   reg [`ALU_OP_WIDTH-1:0]     buf_alu_op_alu2;
+   reg [`SPECTAG_LEN-1:0]      buf_spectag_alu2;
+   reg 			       buf_specbit_alu2;
+
+   //LDST
+   wire [`DATA_LEN-1:0]        result_ldst;
+   wire 		       rrfwe_ldst;
+   wire 		       robwe_ldst;
+   wire [`RRF_SEL-1:0] 	       wrrftag_ldst;
+   wire 		       kill_speculative_ldst;
+   wire 		       busy_next_ldst;
+
+   //wire [`DATA_LEN-1:0]        dmem_data;
+   /*
+   wire [`DATA_LEN-1:0]        dmem_wdata;
+   wire 		       dmem_we;
+   wire [`ADDR_LEN-1:0]        dmem_addr;
+    */
+   wire 		       sb_full;
+   wire 		       hitsb;
+   wire 		       memoccupy_ld;
+   wire [`ADDR_LEN-1:0]        ldaddr;
+   wire [`DATA_LEN-1:0]        lddatasb;
+   wire [`ADDR_LEN-1:0]        retaddr;
+   wire [`DATA_LEN-1:0]        storedata;
+   wire [`ADDR_LEN-1:0]        storeaddr;
+   wire 		       stfin;
+   
+   reg [`DATA_LEN-1:0] 	       buf_ex_src1_ldst;
+   reg [`DATA_LEN-1:0] 	       buf_ex_src2_ldst;
+   reg [`ADDR_LEN-1:0] 	       buf_pc_ldst;
+   reg [`DATA_LEN-1:0] 	       buf_imm_ldst;
+   reg [`RRF_SEL-1:0] 	       buf_rrftag_ldst;
+   reg 			       buf_dstval_ldst;
+   reg [`SPECTAG_LEN-1:0]      buf_spectag_ldst;
+   reg 			       buf_specbit_ldst;
+
+   //MUL
+   wire [`DATA_LEN-1:0]        result_mul;
+   wire 		       rrfwe_mul;
+   wire 		       robwe_mul;
+   wire 		       kill_speculative_mul;
+
+   reg [`DATA_LEN-1:0] 	       buf_ex_src1_mul;
+   reg [`DATA_LEN-1:0] 	       buf_ex_src2_mul;
+   reg [`ADDR_LEN-1:0] 	       buf_pc_mul;
+   reg [`RRF_SEL-1:0] 	       buf_rrftag_mul;
+   reg 			       buf_dstval_mul;
+   reg [`SPECTAG_LEN-1:0]      buf_spectag_mul;
+   reg 			       buf_specbit_mul;
+   reg 			       buf_src1_signed_mul;
+   reg 			       buf_src2_signed_mul;
+   reg 			       buf_sel_lohi_mul;
+   
+   //BRANCH
+   wire 		       prmiss;
+   wire 		       prsuccess;
+   wire [`ADDR_LEN-1:0]        jmpaddr;
+   wire [`ADDR_LEN-1:0]        jmpaddr_taken;
+   wire 		       brcond;
+   wire [`SPECTAG_LEN-1:0]     tagregfix;
+   
+   wire [`DATA_LEN-1:0]        result_branch;
+   wire 		       rrfwe_branch;
+   wire 		       robwe_branch;
+   
+   reg [`DATA_LEN-1:0] 	       buf_ex_src1_branch;
+   reg [`DATA_LEN-1:0] 	       buf_ex_src2_branch;
+   reg [`ADDR_LEN-1:0] 	       buf_pc_branch;
+   reg [`DATA_LEN-1:0] 	       buf_imm_branch;
+   reg [`RRF_SEL-1:0] 	       buf_rrftag_branch;
+   reg 			       buf_dstval_branch;
+   reg [`ALU_OP_WIDTH-1:0]     buf_alu_op_branch;
+   reg [`SPECTAG_LEN-1:0]      buf_spectag_branch;
+   reg 			       buf_specbit_branch;
+   reg [`ADDR_LEN-1:0] 	       buf_praddr_branch;
+   reg [6:0] 		       buf_opcode_branch;
+   
+   //miss prediction fix table
+   wire [`SPECTAG_LEN-1:0] mpft_valid;
+   wire [`SPECTAG_LEN-1:0] spectagfix;
+
+   //COM
+   wire [`RRF_SEL-1:0] 	   comptr;
+   wire [`RRF_SEL-1:0] 	   comptr2;
+   wire [1:0] 		   comnum;
+   wire 		   stcommit;
+   wire 		   arfwe1;
+   wire 		   arfwe2;
+   wire [`REG_SEL-1:0] 	   dstarf1;
+   wire [`REG_SEL-1:0] 	   dstarf2;
+   wire [`ADDR_LEN-1:0]    pc_combranch;
+   wire [`GSH_BHR_LEN-1:0] bhr_combranch;
+   wire 		   brcond_combranch;
+   wire 		   combranch;
+   wire [`ADDR_LEN-1:0]    jmpaddr_combranch;
+   
+   //IF Stage********************************************************
+//    assign stall_IF = stall_ID;
+//    assign kill_IF = prmiss;
+   assign stall_IF = stall_ID | stall_DP;
+   assign kill_IF = prmiss;
+   
+   always @ (posedge clk) begin
+      if (reset) begin
+	 	pc <= `ENTRY_POINT;
+      end else if (prmiss) begin
+	 	pc <= jmpaddr;
+      end else if (stall_IF) begin
+	 	pc <= pc;
+      end else begin
+	 	pc <= npc;
+      end
+   end
+
+   // EDIT: manually cut inst1, want to drive this from the top-level
+   //       we don't need to include the instruction fetch
+   wire [`INSN_LEN-1:0] cut_inst1;
+
+   pipeline_if pipe_if(
+		       .clk(clk),
+		       .reset(reset),
+		       .pc(pc),
+		       .predict_cond(prcond),
+		       .npc(npc),
+		       .inst1(cut_inst1),
+		       .inst2(inst2),
+		       .invalid2(invalid2_pipe),
+		       .btbpht_we(combranch),
+		       .btbpht_pc(pc_combranch),
+		       .btb_jmpdst(jmpaddr_combranch),
+		       .pht_wcond(brcond_combranch),
+		       .mpft_valid(mpft_valid),
+		       .pht_bhr(bhr_combranch), //when PHT write
+		       .prmiss(prmiss),
+		       .prsuccess(prsuccess),
+		       .prtag(buf_spectag_branch),
+		       .bhr(bhr),
+		       .spectagnow(tagreg),
+		       .idata(idata)
+		       );
+
+   always @ (posedge clk) begin
+    if (reset | kill_IF) begin
+		prcond_if <= 0;
+		npc_if <= 0;
+		pc_if <= 0;
+		inst1_if <= 0;
+		inst2_if <= 0;
+		inv1_if <= 1;
+		inv2_if <= 1;
+		bhr_if <= 0;
+	  end else if (~stall_IF) begin
+		prcond_if <= prcond;
+		npc_if <= npc;
+		pc_if <= pc;
+		// EDIT: send the output of the QED module through the pipeline.
+		//inst1_if <= inst1;
+		inst1_if <= qed_instruction;
+		//inst2_if <= inst2;
+		inst2_if <= 32'd0;
+		//inv1_if <= 0;
+		inv1_if <= ~qed_vld_out;   
+		//inv2_if <= invalid2_pipe;
+		inv2_if <= 1'b1;
+		// EDIT END
+		bhr_if <= bhr;
+      end
+   	end // always @ (posedge clk)
+
+   //ID Stage********************************************************
+//   assign stall_ID = stall_DP | ~attachable | (prsuccess & (isbranch1 | isbranch2));
+//   assign kill_ID = prmiss;
+   assign stall_ID = ~attachable | prsuccess;
+   assign kill_ID = (stall_ID & ~stall_DP) | prmiss;
+   
+   assign isbranch1 = (~inv1_if && (rs_ent_1 == `RS_ENT_BRANCH)) ?
+		      1'b1 : 1'b0;
+   assign isbranch2 = (~inv2_if && (rs_ent_2 == `RS_ENT_BRANCH)) ?
+		      1'b1 : 1'b0;
+   assign branchvalid1 = isbranch1 & prcond_if;
+   assign branchvalid2 = isbranch2 & ~branchvalid1;
+   
+   tag_generator taggen(
+			.clk(clk),
+			.reset(reset),
+			.branchvalid1(isbranch1),
+			.branchvalid2(branchvalid2),
+			.prmiss(prmiss),
+			.prsuccess(prsuccess),
+			.enable(~stall_ID & ~stall_DP),
+			.tagregfix(tagregfix),
+			.sptag1(sptag1),
+			.sptag2(sptag2),
+			.speculative1(spec1),
+			.speculative2(spec2),
+			.attachable(attachable),
+			.tagreg(tagreg)
+			);
+   
+   decoder dec1(
+		.inst(inst1_if),
+		.imm_type(imm_type_1),
+		.rs1(rs1_1),
+		.rs2(rs2_1),
+		.rd(rd_1),
+		.src_a_sel(src_a_sel_1),
+		.src_b_sel(src_b_sel_1),
+		.wr_reg(wr_reg_1),
+		.uses_rs1(uses_rs1_1),
+		.uses_rs2(uses_rs2_1),
+		.illegal_instruction(illegal_instruction_1),
+		.alu_op(alu_op_1),
+		.rs_ent(rs_ent_1),
+		.dmem_size(dmem_size_1),
+		.dmem_type(dmem_type_1),
+		.md_req_op(md_req_op_1),
+		.md_req_in_1_signed(md_req_in_1_signed_1),
+		.md_req_in_2_signed(md_req_in_2_signed_1),
+		.md_req_out_sel(md_req_out_sel_1)
+		);
+
+   decoder dec2(
+		.inst(inst2_if),
+		.imm_type(imm_type_2),
+		.rs1(rs1_2),
+		.rs2(rs2_2),
+		.rd(rd_2),
+		.src_a_sel(src_a_sel_2),
+		.src_b_sel(src_b_sel_2),
+		.wr_reg(wr_reg_2),
+		.uses_rs1(uses_rs1_2),
+		.uses_rs2(uses_rs2_2),
+		.illegal_instruction(illegal_instruction_2),
+		.alu_op(alu_op_2),
+		.rs_ent(rs_ent_2),
+		.dmem_size(dmem_size_2),
+		.dmem_type(dmem_type_2),
+		.md_req_op(md_req_op_2),
+		.md_req_in_1_signed(md_req_in_1_signed_2),
+		.md_req_in_2_signed(md_req_in_2_signed_2),
+		.md_req_out_sel(md_req_out_sel_2)
+		);
+
+   always @ (posedge clk) begin
+      if (reset | kill_ID) begin
+	 imm_type_1_id <= 0;
+	 rs1_1_id <= 0;
+	 rs2_1_id <= 0;
+	 rd_1_id <= 0;
+	 src_a_sel_1_id <= 0;
+	 src_b_sel_1_id <= 0;
+	 wr_reg_1_id <= 0;
+	 uses_rs1_1_id <= 0;
+	 uses_rs2_1_id <= 0;
+	 illegal_instruction_1_id <= 0;
+	 alu_op_1_id <= 0;
+	 rs_ent_1_id <= 0;
+	 dmem_size_1_id <= 0;
+	 dmem_type_1_id <= 0;			  
+	 md_req_op_1_id <= 0;
+	 md_req_in_1_signed_1_id <= 0;
+	 md_req_in_2_signed_1_id <= 0;
+	 md_req_out_sel_1_id <= 0;
+	 imm_type_2_id <= 0;
+	 rs1_2_id <= 0;
+	 rs2_2_id <= 0;
+	 rd_2_id <= 0;
+	 src_a_sel_2_id <= 0;
+	 src_b_sel_2_id <= 0;
+	 wr_reg_2_id <= 0;
+	 uses_rs1_2_id <= 0;
+	 uses_rs2_2_id <= 0;
+	 illegal_instruction_2_id <= 0;
+	 alu_op_2_id <= 0;
+	 rs_ent_2_id <= 0;
+	 dmem_size_2_id <= 0;
+	 dmem_type_2_id <= 0;			  
+	 md_req_op_2_id <= 0;
+	 md_req_in_1_signed_2_id <= 0;
+	 md_req_in_2_signed_2_id <= 0;
+	 md_req_out_sel_2_id <= 0;
+
+	 rs1_2_eq_dst1_id <= 0;
+  	 rs2_2_eq_dst1_id <= 0;
+	 sptag1_id <= 0;
+	 sptag2_id <= 0;
+	 tagreg_id <= 0;
+//	 spec1_id <= 0;
+//	 spec2_id <= 0;
+	 inst1_id <= 0;
+	 inst2_id <= 0;
+	 prcond1_id <= 0;
+	 prcond2_id <= 0;
+	 inv1_id <= 1;
+	 inv2_id <= 1;
+	 praddr1_id <= 0;
+	 praddr2_id <= 0;
+	 pc_id <= 0;
+	 bhr_id <= 0;
+	 isbranch1_id <= 0;
+	 isbranch2_id <= 0;
+	 
+      end else if (~stall_DP) begin
+	 imm_type_1_id <= imm_type_1;
+	 rs1_1_id <= rs1_1;
+	 rs2_1_id <= rs2_1;
+	 rd_1_id <= rd_1;
+	 src_a_sel_1_id <= src_a_sel_1;
+	 src_b_sel_1_id <= src_b_sel_1;
+	 wr_reg_1_id <= wr_reg_1;
+	 uses_rs1_1_id <= uses_rs1_1;
+	 uses_rs2_1_id <= uses_rs2_1;
+	 illegal_instruction_1_id <= illegal_instruction_1;
+	 alu_op_1_id <= alu_op_1;
+	 rs_ent_1_id <= inv1_if ? 0 : rs_ent_1;
+	 dmem_size_1_id <= dmem_size_1;
+	 dmem_type_1_id <= dmem_type_1;			  
+	 md_req_op_1_id <= md_req_op_1;
+	 md_req_in_1_signed_1_id <= md_req_in_1_signed_1;
+	 md_req_in_2_signed_1_id <= md_req_in_2_signed_1;
+	 md_req_out_sel_1_id <= md_req_out_sel_1;
+	 imm_type_2_id <= imm_type_2;
+	 rs1_2_id <= rs1_2;
+	 rs2_2_id <= rs2_2;
+	 rd_2_id <= rd_2;
+	 src_a_sel_2_id <= src_a_sel_2;
+	 src_b_sel_2_id <= src_b_sel_2;
+	 wr_reg_2_id <= wr_reg_2;
+	 uses_rs1_2_id <= uses_rs1_2;
+	 uses_rs2_2_id <= uses_rs2_2;
+	 illegal_instruction_2_id <= illegal_instruction_2;
+	 alu_op_2_id <= alu_op_2;
+	 rs_ent_2_id <= (inv2_if | (prcond_if & isbranch1)) ? 0 : rs_ent_2;
+	 dmem_size_2_id <= dmem_size_2;
+	 dmem_type_2_id <= dmem_type_2;			  
+	 md_req_op_2_id <= md_req_op_2;
+	 md_req_in_1_signed_2_id <= md_req_in_1_signed_2;
+	 md_req_in_2_signed_2_id <= md_req_in_2_signed_2;
+	 md_req_out_sel_2_id <= md_req_out_sel_2;
+	 
+	 rs1_2_eq_dst1_id <= (rs1_2 == rd_1 && wr_reg_1) ? 1'b1 : 1'b0;
+  	 rs2_2_eq_dst1_id <= (rs2_2 == rd_1 && wr_reg_1) ? 1'b1 : 1'b0;
+	 sptag1_id <= sptag1;
+	 sptag2_id <= sptag2;
+	 tagreg_id <= tagreg;
+//	 spec1_id <= spec1;
+//	 spec2_id <= spec2;
+	 inst1_id <= inst1_if;
+	 inst2_id <= inst2_if;
+	 prcond1_id <= prcond_if & isbranch1;
+	 prcond2_id <= isbranch2 & prcond_if & ~isbranch1;
+	 inv1_id <= inv1_if;
+	 inv2_id <= inv2_if | (prcond_if & isbranch1);
+	 /*
+	 praddr1_id <= prcond_if & isbranch1 ? npc_if : pc_if + 4;
+	 praddr2_id <= prcond_if & ~isbranch1 & isbranch2 ?
+		       npc_if : pc_if + 8;
+	  */
+	 praddr1_id <= (prcond_if & isbranch1) ? npc_if : (pc_if + 4);
+	 praddr2_id <= npc_if;
+	 pc_id <= pc_if;
+	 bhr_id <= bhr_if;
+	 isbranch1_id <= isbranch1;
+	 isbranch2_id <= isbranch2;
+	 
+      end
+   end
+
+   //Invalidation of specbit when prsuccess(stall)
+   always @ (posedge clk) begin
+      if (reset | kill_ID) begin
+	 spec1_id <= 0;
+	 spec2_id <= 0;
+      end else if (prsuccess) begin
+	 spec1_id <= (spec1_id && (buf_spectag_branch == sptag1_id)) ?
+		     1'b0 : spec1_id;
+	 spec2_id <= (spec2_id && (buf_spectag_branch == sptag2_id)) ?
+		     1'b0 : spec2_id;
+      end else if (~stall_ID) begin
+	 spec1_id <= spec1;
+	 spec2_id <= spec2;
+      end
+   end
+   
+   //DP & SW Stage***************************************************
+   assign stall_DP = ~allocatable_alu | ~allocatable_ldst |
+		     ~allocatable_mul | ~allocatable_branch | ~alloc_rrf | prsuccess;
+
+   assign kill_DP = prmiss;
+   
+   
+   sourceoperand_manager sopm1_1(
+				 .arfdata(adat1_1),
+				 .arf_busy(abusy1_1),
+				 .rrf_valid(rvalid1_1),
+				 .rrftag(rs1_1tag),
+				 .rrfdata(rdat1_1),
+				 .dst1_renamed(dst1_renamed),
+				 .src_eq_dst1(1'b0),
+				 //EDIT mutation: All registers incorrectly identified as GPR0
+				 .src_eq_0((rs1_1_id == 0) ? 1'b1 : 1'b0),
+				 //.src_eq_0((rs1_1_id == 0) ? 1'b1 : 1'b1),
+				 //END EDIT
+				 .src(opr1_1),
+				 .rdy(rdy1_1)
+				 );
+
+   sourceoperand_manager sopm2_1(
+				 .arfdata(adat2_1),
+				 .arf_busy(abusy2_1),
+				 .rrf_valid(rvalid2_1),
+				 .rrftag(rs2_1tag),
+				 .rrfdata(rdat2_1),
+				 .dst1_renamed(dst1_renamed),
+				 .src_eq_dst1(1'b0),
+				 // EDIT mutation: All source operands in sourceoperand_manager are redirected to GPR0.
+				 //.src_eq_0((rs2_1_id == 0) ? 1'b1 : 1'b1),
+				 .src_eq_0((rs2_1_id == 0) ? 1'b1 : 1'b0),
+				 // END EDIT
+				 .src(opr2_1),
+				 .rdy(rdy2_1)
+				 );
+
+   sourceoperand_manager sopm1_2(
+				 .arfdata(adat1_2),
+				 .arf_busy(abusy1_2),
+				 .rrf_valid(rvalid1_2),
+				 .rrftag(rs1_2tag),
+				 .rrfdata(rdat1_2),
+				 .dst1_renamed(dst1_renamed),
+				 .src_eq_dst1(rs1_2_eq_dst1_id),
+				 .src_eq_0((rs1_2_id == 0) ? 1'b1 : 1'b0),
+				 .src(opr1_2),
+				 .rdy(rdy1_2)
+				 );
+
+   sourceoperand_manager sopm2_2(
+				 .arfdata(adat2_2),
+				 .arf_busy(abusy2_2),
+				 .rrf_valid(rvalid2_2),
+				 .rrftag(rs2_2tag),
+				 .rrfdata(rdat2_2),
+				 .dst1_renamed(dst1_renamed),
+				 .src_eq_dst1(rs2_2_eq_dst1_id),
+				 .src_eq_0((rs2_2_id == 0) ? 1'b1 : 1'b0),
+				 .src(opr2_2),
+				 .rdy(rdy2_2)
+				 );
+   
+   rrf_freelistmanager rrf_fl(
+			      .clk(clk),
+			      .reset(reset),
+			      .invalid1(inv1_id),
+			      .invalid2(inv2_id),
+			      .comnum(comnum),
+			      .prmiss(prmiss),
+			      .rrftagfix(rrftagfix),
+			      .rename_dst1(dst1_renamed),
+			      .rename_dst2(dst2_renamed),
+			      .allocatable(alloc_rrf),
+			      .stall_DP(stall_DP),
+			      .freenum(freenum),
+			      .rrfptr(rrfptr),
+			      .comptr(comptr),
+			      .nextrrfcyc(nextrrfcyc)
+			      );
+   
+   arf aregfile(
+		.clk(clk),
+		.reset(reset),
+		.rs1_1(rs1_1_id),
+		.rs2_1(rs2_1_id),
+		.rs1_2(rs1_2_id),
+		.rs2_2(rs2_2_id),
+		.rs1_1data(adat1_1),
+		.rs2_1data(adat2_1),
+		.rs1_2data(adat1_2),
+		.rs2_2data(adat2_2),
+		.wreg1(dstarf1),
+		.wreg2(dstarf2),
+		.wdata1(com1data),
+		.wdata2(com2data),
+		.we1(arfwe1),
+		.we2(arfwe2),
+		.wrrfent1(comptr),
+		.wrrfent2(comptr2),
+		.rs1_1tag(rs1_1tag),
+		.rs2_1tag(rs2_1tag),
+		.rs1_2tag(rs1_2tag),
+		.rs2_2tag(rs2_2tag),
+		.tagbusy1_addr(rd_1_id),
+		.tagbusy2_addr(rd_2_id),
+		.tagbusy1_we(~inv1_id & ~stall_DP & wr_reg_1_id),
+		.tagbusy2_we(~inv2_id & ~stall_DP & wr_reg_2_id),
+		.settag1(dst1_renamed),
+		.settag2(dst2_renamed),
+		.tagbusy1_spectag(sptag1_id),
+		.tagbusy2_spectag(sptag2_id),
+		.rs1_1busy(abusy1_1),
+		.rs2_1busy(abusy2_1),
+		.rs1_2busy(abusy1_2),
+		.rs2_2busy(abusy2_2),
+		.prmiss(prmiss),
+		.prsuccess(prsuccess),
+		.prtag(buf_spectag_branch),
+//		.mpft_valid1(mpft_valid1_id), //PRsuccess & stall Bug
+//		.mpft_valid2(mpft_valid2_id)
+		.mpft_valid1(mpft_valid & 
+			     (isbranch1_id ? ~sptag1_id : ~(`SPECTAG_LEN'b0)) &
+			     (isbranch2_id ? ~sptag2_id : ~(`SPECTAG_LEN'b0))),
+		.mpft_valid2(mpft_valid & 
+			     (isbranch2_id ? ~sptag2_id : ~(`SPECTAG_LEN'b0))),
+	    // EDIT
+		.mem0(gpr0_o),
+		.mem1(gpr1_o),
+		.mem2(gpr2_o),
+		.mem3(gpr3_o),
+		.mem4(gpr4_o),
+		.mem5(gpr5_o),
+		.mem6(gpr6_o),
+		.mem7(gpr7_o),
+		.mem8(gpr8_o),
+		.mem9(gpr9_o),
+		.mem10(gpr10_o),
+		.mem11(gpr11_o),
+		.mem12(gpr12_o),
+		.mem13(gpr13_o),
+		.mem14(gpr14_o),
+		.mem15(gpr15_o),
+		.mem16(gpr16_o),
+		.mem17(gpr17_o),
+		.mem18(gpr18_o),
+		.mem19(gpr19_o),
+		.mem20(gpr20_o),
+		.mem21(gpr21_o),
+		.mem22(gpr22_o),
+		.mem23(gpr23_o),
+		.mem24(gpr24_o),
+		.mem25(gpr25_o),
+		.mem26(gpr26_o),
+		.mem27(gpr27_o),
+		.mem28(gpr28_o),
+		.mem29(gpr29_o),
+		.mem30(gpr30_o),
+		.mem31(gpr31_o)
+		// EDIT: END
+		);
+   
+   assign	rrftagfix = buf_rrftag_branch + 1;
+   rrf rregfile(
+		.clk(clk),
+		.reset(reset),
+		.rs1_1tag(rs1_1tag),
+		.rs2_1tag(rs2_1tag),
+		.rs1_2tag(rs1_2tag),
+		.rs2_2tag(rs2_2tag),
+		.com1tag(comptr),
+		.com2tag(comptr2),
+		.rs1_1valid(rvalid1_1),
+		.rs2_1valid(rvalid2_1),
+		.rs1_2valid(rvalid1_2),
+		.rs2_2valid(rvalid2_2),
+		.rs1_1data(rdat1_1),
+		.rs2_1data(rdat2_1),
+		.rs1_2data(rdat1_2),
+		.rs2_2data(rdat2_2),
+		.com1data(com1data),
+		.com2data(com2data),
+		.wrrfaddr1(buf_rrftag_alu1),
+		.wrrfaddr2(buf_rrftag_alu2),
+		.wrrfaddr3(wrrftag_ldst),
+		.wrrfaddr4(buf_rrftag_branch),      
+		.wrrfaddr5(buf_rrftag_mul),
+		.wrrfdata1(result_alu1),
+		.wrrfdata2(result_alu2),
+		.wrrfdata3(result_ldst),
+		.wrrfdata4(result_branch),
+		.wrrfdata5(result_mul),
+		.wrrfen1(rrfwe_alu1),
+		.wrrfen2(rrfwe_alu2),
+		.wrrfen3(rrfwe_ldst),
+		.wrrfen4(rrfwe_branch),
+		.wrrfen5(rrfwe_mul),
+		.dpaddr1(dst1_renamed),
+		.dpaddr2(dst2_renamed),
+		.dpen1(~stall_DP & ~kill_DP & ~inv1_id), // hoge
+		.dpen2(~stall_DP & ~kill_DP & ~inv2_id)  // hoge
+		);
+
+
+   src_manager srcmng1_1(
+			 .opr(opr1_1),
+			 .opr_rdy(rdy1_1),
+			 .exrslt1(result_alu1),
+			 .exdst1(buf_rrftag_alu1),
+			 .kill_spec1(kill_speculative_alu1 | ~robwe_alu1),
+			 .exrslt2(result_alu2),
+			 .exdst2(buf_rrftag_alu2),
+			 .kill_spec2(kill_speculative_alu2 | ~robwe_alu2),
+			 .exrslt3(result_ldst),
+			 .exdst3(wrrftag_ldst),
+			 .kill_spec3(kill_speculative_ldst | ~robwe_ldst),
+			 .exrslt4(result_branch),
+			 .exdst4(buf_rrftag_branch),
+			 .kill_spec4(~robwe_branch),
+			 .exrslt5(result_mul),
+			 .exdst5(buf_rrftag_mul),
+			 .kill_spec5(kill_speculative_mul | ~robwe_mul),
+			 .src(src1_1),
+			 .resolved(resolved1_1)
+			 );
+
+   src_manager srcmng2_1(
+			 .opr(opr2_1),
+			 .opr_rdy(rdy2_1),
+			 .exrslt1(result_alu1),
+			 .exdst1(buf_rrftag_alu1),
+			 .kill_spec1(kill_speculative_alu1 | ~robwe_alu1),
+			 .exrslt2(result_alu2),
+			 .exdst2(buf_rrftag_alu2),
+			 .kill_spec2(kill_speculative_alu2 | ~robwe_alu2),
+			 .exrslt3(result_ldst),
+			 .exdst3(wrrftag_ldst),
+			 .kill_spec3(kill_speculative_ldst | ~robwe_ldst),
+			 .exrslt4(result_branch),
+			 .exdst4(buf_rrftag_branch),
+			 .kill_spec4(~robwe_branch),
+			 .exrslt5(result_mul),
+			 .exdst5(buf_rrftag_mul),
+			 .kill_spec5(kill_speculative_mul | ~robwe_mul),
+			 .src(src2_1),
+			 .resolved(resolved2_1)
+			 );
+
+   src_manager srcmng1_2(
+			 .opr(opr1_2),
+			 .opr_rdy(rdy1_2),
+			 .exrslt1(result_alu1),
+			 .exdst1(buf_rrftag_alu1),
+			 .kill_spec1(kill_speculative_alu1 | ~robwe_alu1),
+			 .exrslt2(result_alu2),
+			 .exdst2(buf_rrftag_alu2),
+			 .kill_spec2(kill_speculative_alu2 | ~robwe_alu2),
+			 .exrslt3(result_ldst),
+			 .exdst3(wrrftag_ldst),
+			 .kill_spec3(kill_speculative_ldst | ~robwe_ldst),
+			 .exrslt4(result_branch),
+			 .exdst4(buf_rrftag_branch),
+			 .kill_spec4(~robwe_branch),
+			 .exrslt5(result_mul),
+			 .exdst5(buf_rrftag_mul),
+			 .kill_spec5(kill_speculative_mul | ~robwe_mul),
+			 .src(src1_2),
+			 .resolved(resolved1_2)
+			 );
+
+   src_manager srcmng2_2(
+			 .opr(opr2_2),
+			 .opr_rdy(rdy2_2),
+			 .exrslt1(result_alu1),
+			 .exdst1(buf_rrftag_alu1),
+			 .kill_spec1(kill_speculative_alu1 | ~robwe_alu1),
+			 .exrslt2(result_alu2),
+			 .exdst2(buf_rrftag_alu2),
+			 .kill_spec2(kill_speculative_alu2 | ~robwe_alu2),
+			 .exrslt3(result_ldst),
+			 .exdst3(wrrftag_ldst),
+			 .kill_spec3(kill_speculative_ldst | ~robwe_ldst),
+			 .exrslt4(result_branch),
+			 .exdst4(buf_rrftag_branch),
+			 .kill_spec4(~robwe_branch),
+			 .exrslt5(result_mul),
+			 .exdst5(buf_rrftag_mul),
+			 .kill_spec5(kill_speculative_mul | ~robwe_mul),
+			 .src(src2_2),
+			 .resolved(resolved2_2)
+			 );
+
+   imm_gen immgen1(
+		   .inst(inst1_id),
+		   .imm_type(imm_type_1_id),
+		   .imm(imm1)
+		   );
+
+   imm_gen immgen2(
+		   .inst(inst2_id),
+		   .imm_type(imm_type_2_id),
+		   .imm(imm2)
+		   );
+
+   brimm_gen brimmgen1(
+		       .inst(inst1_id),
+		       .brimm(brimm1)
+		       );
+
+   brimm_gen brimmgen2(
+		       .inst(inst2_id),
+		       .brimm(brimm2)
+		       );
+
+   rs_requestgenerator rs_reqgen(
+				 .rsent_1(rs_ent_1_id),
+				 .rsent_2(rs_ent_2_id),
+				 .req1_alu(req1_alu),
+				 .req2_alu(req2_alu),
+				 .req_alunum(req_alunum),
+				 .req1_branch(req1_branch),
+				 .req2_branch(req2_branch),
+				 .req_branchnum(req_branchnum),
+				 .req1_mul(req1_mul),
+				 .req2_mul(req2_mul),
+				 .req_mulnum(req_mulnum),
+				 .req1_ldst(req1_ldst),
+				 .req2_ldst(req2_ldst),
+				 .req_ldstnum(req_ldstnum)
+				 );
+
+   
+   //Reservation Station(with Allocate unit, Issue unit)
+   //lowest bit of allocent is the selector of RS_alu1/2
+   assign 		 rsalu1_we1 = ~allocent1_alu[0];
+   assign 		 rsalu1_we2 = req1_alu ? 
+			 ~allocent2_alu[0] : ~allocent1_alu[0];
+   assign 		 rsalu2_we1 = allocent1_alu[0];
+   assign 		 rsalu2_we2 = req1_alu ? 
+			 allocent2_alu[0] : allocent1_alu[0];
+   
+   assign busyvec_alu = 
+			{
+			 busyvec_alu2[7],busyvec_alu1[7],busyvec_alu2[6],busyvec_alu1[6],
+			 busyvec_alu2[5],busyvec_alu1[5],busyvec_alu2[4],busyvec_alu1[4],
+			 busyvec_alu2[3],busyvec_alu1[3],busyvec_alu2[2],busyvec_alu1[2],
+			 busyvec_alu2[1],busyvec_alu1[1],busyvec_alu2[0],busyvec_alu1[0]
+			 };
+
+   assign ready_alu = 
+		      {
+		       ready_alu2[7],ready_alu1[7],ready_alu2[6],ready_alu1[6],
+		       ready_alu2[5],ready_alu1[5],ready_alu2[4],ready_alu1[4],
+		       ready_alu2[3],ready_alu1[3],ready_alu2[2],ready_alu1[2],
+		       ready_alu2[1],ready_alu1[1],ready_alu2[0],ready_alu1[0]
+		       };
+
+   assign 		   issue_alu1 = ~prmiss & issuevalid_alu1;
+   assign 		   issue_alu2 = ~prmiss & issuevalid_alu2;
+   
+   allocateunit #(2*`ALU_ENT_NUM, `ALU_ENT_SEL+1) alloc_alu(
+							    .busy(busyvec_alu), //RS_BUSY
+							    //      .en1(),
+							    //      .en2(),
+							    .free_ent1(allocent1_alu),
+							    .free_ent2(allocent2_alu),
+							    .reqnum(req_alunum),
+							    .allocatable(allocatable_alu)
+							    );
+
+   /*
+    prioenc #(2*`ALU_ENT_NUM, `ALU_ENT_SEL+1) issue_alu
+    (
+    .in(~ready_alu),
+    .out(issueent_alu),
+    .en(issuevalid_alu)
+    );
+    */
+/*
+   prioenc #(`ALU_ENT_NUM, `ALU_ENT_SEL) isunt_alu1(
+						    .in(~ready_alu1),
+						    .out(issueentidx_alu1),
+						    .en(issuevalid_alu1)
+						    );
+
+   prioenc #(`ALU_ENT_NUM, `ALU_ENT_SEL) isunt_alu2(
+						    .in(~ready_alu2),
+						    .out(issueentidx_alu2),
+						    .en(issuevalid_alu2)
+						    );
+*/
+   assign issuevalid_alu1 = ~entval_alu1[`RRF_SEL+1];
+   assign issuevalid_alu2 = ~entval_alu2[`RRF_SEL+1];
+   
+   oldest_finder8 isunt_alu1
+     (
+      .entvec({`ALU_ENT_SEL'h7, `ALU_ENT_SEL'h6, `ALU_ENT_SEL'h5, `ALU_ENT_SEL'h4,
+	       `ALU_ENT_SEL'h3, `ALU_ENT_SEL'h2, `ALU_ENT_SEL'h1, `ALU_ENT_SEL'h0}),
+      .valvec(histvect1),
+      .oldent(issueent_alu1),
+      .oldval(entval_alu1)
+      );
+
+   oldest_finder8 isunt_alu2
+     (
+      .entvec({`ALU_ENT_SEL'h7, `ALU_ENT_SEL'h6, `ALU_ENT_SEL'h5, `ALU_ENT_SEL'h4,
+	       `ALU_ENT_SEL'h3, `ALU_ENT_SEL'h2, `ALU_ENT_SEL'h1, `ALU_ENT_SEL'h0}),
+      .valvec(histvect2),
+      .oldent(issueent_alu2),
+      .oldval(entval_alu2)
+      );
+   
+   
+   rs_alu reserv_alu1(
+		      //System
+		      .clk(clk),
+		      .reset(reset),
+		      .busyvec(busyvec_alu1),
+		      .prmiss(prmiss),
+		      .prsuccess(prsuccess),
+		      .prtag(buf_spectag_branch),
+		      .specfixtag(spectagfix),
+		      .histvect(histvect1),
+		      .nextrrfcyc(nextrrfcyc),
+		      //WriteSignal
+		      .clearbusy(issue_alu1), //Issue 
+		      .issueaddr(issueent_alu1), //= raddr, clsbsyadr
+		      .we1(~stall_DP & ~kill_DP & req1_alu & rsalu1_we1), //alloc1
+		      .we2(~stall_DP & ~kill_DP & req2_alu & rsalu1_we2), //alloc2
+		      .waddr1(allocent1_alu[`ALU_ENT_SEL:1]), //allocent1
+		      .waddr2(req1_alu ? 
+			      allocent2_alu[`ALU_ENT_SEL:1] : 
+			      allocent1_alu[`ALU_ENT_SEL:1]), //allocent2
+		      //WriteSignal1
+		      .wpc_1(pc_id),
+		      .wsrc1_1(src1_1),
+		      .wsrc2_1(src2_1),
+		      .wvalid1_1(~uses_rs1_1_id | resolved1_1),
+		      .wvalid2_1(~uses_rs2_1_id | resolved2_1),
+		      .wimm_1(imm1),
+		      .wrrftag_1(dst1_renamed),
+		      .wdstval_1(wr_reg_1_id),
+		      .wsrc_a_1(src_a_sel_1_id),
+		      .wsrc_b_1(src_b_sel_1_id),
+		      .walu_op_1(alu_op_1_id),
+		      .wspectag_1(sptag1_id),
+		      .wspecbit_1(spec1_id),
+		      //WriteSignal2
+		      .wpc_2(pc_id + 4),
+		      .wsrc1_2(src1_2),
+		      .wsrc2_2(src2_2),
+		      .wvalid1_2(~uses_rs1_2_id | resolved1_2),
+		      .wvalid2_2(~uses_rs2_2_id | resolved2_2),
+		      .wimm_2(imm2),
+		      .wrrftag_2(dst2_renamed),
+		      .wdstval_2(wr_reg_2_id),
+		      .wsrc_a_2(src_a_sel_2_id),
+		      .wsrc_b_2(src_b_sel_2_id),
+		      .walu_op_2(alu_op_2_id),
+		      .wspectag_2(sptag2_id),
+		      .wspecbit_2(spec2_id),
+		      //ReadSignal
+		      .ex_src1(ex_src1_alu1),
+		      .ex_src2(ex_src2_alu1),
+		      .ready(ready_alu1),
+		      .pc(pc_alu1),
+		      .imm(imm_alu1),
+		      .rrftag(rrftag_alu1),
+		      .dstval(dstval_alu1),
+		      .src_a(src_a_alu1),
+		      .src_b(src_b_alu1),
+		      .alu_op(alu_op_alu1),
+		      .spectag(spectag_alu1),
+		      .specbit(specbit_alu1),
+		      //EXRSLT
+		      .exrslt1(result_alu1),
+		      .exdst1(buf_rrftag_alu1),
+		      .kill_spec1(kill_speculative_alu1 | ~robwe_alu1),
+		      .exrslt2(result_alu2),
+		      .exdst2(buf_rrftag_alu2),
+		      .kill_spec2(kill_speculative_alu2 | ~robwe_alu2),
+		      .exrslt3(result_ldst),
+		      .exdst3(wrrftag_ldst),
+		      .kill_spec3(kill_speculative_ldst | ~robwe_ldst),
+		      .exrslt4(result_branch),
+		      .exdst4(buf_rrftag_branch),
+		      .kill_spec4(~robwe_branch),
+		      .exrslt5(result_mul),
+		      .exdst5(buf_rrftag_mul),
+		      .kill_spec5(kill_speculative_mul | ~robwe_mul)
+		      );
+
+   rs_alu reserv_alu2(
+		      //System
+		      .clk(clk),
+		      .reset(reset),
+		      .busyvec(busyvec_alu2),
+		      .prmiss(prmiss),
+		      .prsuccess(prsuccess),
+		      .prtag(buf_spectag_branch),
+		      .specfixtag(spectagfix),
+		      .histvect(histvect2),
+		      .nextrrfcyc(nextrrfcyc),
+		      //WriteSignal
+		      .clearbusy(issue_alu2), //Issue 
+		      .issueaddr(issueent_alu2), //= raddr, clsbsyadr
+		      .we1(~stall_DP & ~kill_DP & req1_alu & rsalu2_we1), //alloc1
+		      .we2(~stall_DP & ~kill_DP & req2_alu & rsalu2_we2), //alloc2
+		      .waddr1(allocent1_alu[`ALU_ENT_SEL:1]), //allocent1
+		      .waddr2(req1_alu ? 
+			      allocent2_alu[`ALU_ENT_SEL:1] : 
+			      allocent1_alu[`ALU_ENT_SEL:1]), //allocent2
+		      //WriteSignal1
+		      .wpc_1(pc_id),
+		      .wsrc1_1(src1_1),
+		      .wsrc2_1(src2_1),
+		      .wvalid1_1(~uses_rs1_1_id | resolved1_1),
+		      .wvalid2_1(~uses_rs2_1_id | resolved2_1),
+		      .wimm_1(imm1),
+		      .wrrftag_1(dst1_renamed),
+		      .wdstval_1(wr_reg_1_id),
+		      .wsrc_a_1(src_a_sel_1_id),
+		      .wsrc_b_1(src_b_sel_1_id),
+		      .walu_op_1(alu_op_1_id),
+		      .wspectag_1(sptag1_id),
+		      .wspecbit_1(spec1_id),
+		      //WriteSignal2
+		      .wpc_2(pc_id + 4),
+		      .wsrc1_2(src1_2),
+		      .wsrc2_2(src2_2),
+		      .wvalid1_2(~uses_rs1_2_id | resolved1_2),
+		      .wvalid2_2(~uses_rs2_2_id | resolved2_2),
+		      .wimm_2(imm2),
+		      .wrrftag_2(dst2_renamed),
+		      .wdstval_2(wr_reg_2_id),
+		      .wsrc_a_2(src_a_sel_2_id),
+		      .wsrc_b_2(src_b_sel_2_id),
+		      .walu_op_2(alu_op_2_id),
+		      .wspectag_2(sptag2_id),
+		      .wspecbit_2(spec2_id),
+		      //ReadSignal
+		      .ex_src1(ex_src1_alu2),
+		      .ex_src2(ex_src2_alu2),
+		      .ready(ready_alu2),
+		      .pc(pc_alu2),
+		      .imm(imm_alu2),
+		      .rrftag(rrftag_alu2),
+		      .dstval(dstval_alu2),
+		      .src_a(src_a_alu2),
+		      .src_b(src_b_alu2),
+		      .alu_op(alu_op_alu2),
+		      .spectag(spectag_alu2),
+		      .specbit(specbit_alu2),
+		      //EXRSLT
+		      .exrslt1(result_alu1),
+		      .exdst1(buf_rrftag_alu1),
+		      .kill_spec1(kill_speculative_alu1 | ~robwe_alu1),
+		      .exrslt2(result_alu2),
+		      .exdst2(buf_rrftag_alu2),
+		      .kill_spec2(kill_speculative_alu2 | ~robwe_alu2),
+		      .exrslt3(result_ldst),
+		      .exdst3(wrrftag_ldst),
+		      .kill_spec3(kill_speculative_ldst | ~robwe_ldst),
+		      .exrslt4(result_branch),
+		      .exdst4(buf_rrftag_branch),
+		      .kill_spec4(~robwe_branch),
+		      .exrslt5(result_mul),
+		      .exdst5(buf_rrftag_mul),
+		      .kill_spec5(kill_speculative_mul | ~robwe_mul)
+		      );
+
+
+   assign allocent2_ldst = allocent1_ldst + 1;
+   assign issue_ldst = ~prmiss & issuevalid_ldst;
+
+   alloc_issue_ino #(`LDST_ENT_SEL, `LDST_ENT_NUM) ai_ldst
+     (
+      .clk(clk),
+      .reset(reset),
+      .reqnum(req_ldstnum),
+      .busyvec(busyvec_ldst),
+      .prbusyvec_next(prbusyvec_next_ldst),
+      .readyvec(ready_ldst),
+      .prmiss(prmiss),
+      .exunit_busynext(busy_next_ldst),
+      .stall_DP(stall_DP),
+      .kill_DP(kill_DP),
+      .allocptr(allocent1_ldst),
+      .allocatable(allocatable_ldst),
+      .issueptr(issueent_ldst),
+      .issuevalid(issuevalid_ldst)
+      );
+   
+   rs_ldst reserv_ldst(
+		       //System
+		       .clk(clk),
+		       .reset(reset),
+		       .busyvec(busyvec_ldst),
+		       .prmiss(prmiss),
+		       .prsuccess(prsuccess),
+		       .prtag(buf_spectag_branch),
+		       .specfixtag(spectagfix),
+		       .prbusyvec_next(prbusyvec_next_ldst),
+		       //WriteSignal
+		       .clearbusy(issue_ldst), //Issue 
+		       .issueaddr(issueent_ldst), //= raddr, clsbsyadr
+		       .we1(~stall_DP & ~kill_DP & req1_ldst), //alloc1
+		       .we2(~stall_DP & ~kill_DP & req2_ldst), //alloc2
+		       .waddr1(allocent1_ldst), //allocent1
+		       .waddr2(req1_ldst ? 
+			       allocent2_ldst : allocent1_ldst), //allocent2
+		       //WriteSignal1
+		       .wpc_1(pc_id),
+		       .wsrc1_1(src1_1),
+		       .wsrc2_1(src2_1),
+		       .wvalid1_1(~uses_rs1_1_id | resolved1_1),
+		       .wvalid2_1(~uses_rs2_1_id | resolved2_1),
+		       .wimm_1(imm1),
+		       .wrrftag_1(dst1_renamed),
+		       .wdstval_1(wr_reg_1_id),
+		       .wspectag_1(sptag1_id),
+		       .wspecbit_1(spec1_id),
+		       //WriteSignal2
+		       .wpc_2(pc_id + 4),
+		       .wsrc1_2(src1_2),
+		       .wsrc2_2(src2_2),
+		       .wvalid1_2(~uses_rs1_2_id | resolved1_2),
+		       .wvalid2_2(~uses_rs2_2_id | resolved2_2),
+		       .wimm_2(imm2),
+		       .wrrftag_2(dst2_renamed),
+		       .wdstval_2(wr_reg_2_id),
+		       .wspectag_2(sptag2_id),
+		       .wspecbit_2(spec2_id),
+		       //ReadSignal
+		       .ex_src1(ex_src1_ldst),
+		       .ex_src2(ex_src2_ldst),
+		       .ready(ready_ldst),
+		       .pc(pc_ldst),
+		       .imm(imm_ldst),
+		       .rrftag(rrftag_ldst),
+		       .dstval(dstval_ldst),
+		       .spectag(spectag_ldst),
+		       .specbit(specbit_ldst),
+		       //EXRSLT
+		       .exrslt1(result_alu1),
+		       .exdst1(buf_rrftag_alu1),
+		       .kill_spec1(kill_speculative_alu1 | ~robwe_alu1),
+		       .exrslt2(result_alu2),
+		       .exdst2(buf_rrftag_alu2),
+		       .kill_spec2(kill_speculative_alu2 | ~robwe_alu2),
+		       .exrslt3(result_ldst),
+		       .exdst3(wrrftag_ldst),
+		       .kill_spec3(kill_speculative_ldst | ~robwe_ldst),
+		       .exrslt4(result_branch),
+		       .exdst4(buf_rrftag_branch),
+		       .kill_spec4(~robwe_branch),
+		       .exrslt5(result_mul),
+		       .exdst5(buf_rrftag_mul),
+		       .kill_spec5(kill_speculative_mul | ~robwe_mul)
+		       );
+
+
+   assign allocent2_branch = allocent1_branch + 1;
+   assign issue_branch = ~prmiss & issuevalid_branch;
+   
+   alloc_issue_ino ai_branch(
+			     .clk(clk),
+			     .reset(reset),
+			     .reqnum(req_branchnum),
+			     .busyvec(busyvec_branch),
+			     .prbusyvec_next(prbusyvec_next_branch),
+			     .readyvec(ready_branch),
+			     .prmiss(prmiss),
+			     .exunit_busynext(1'b0),
+			     .stall_DP(stall_DP),
+			     .kill_DP(kill_DP),
+			     .allocptr(allocent1_branch),
+			     .allocatable(allocatable_branch),
+			     .issueptr(issueent_branch),
+			     .issuevalid(issuevalid_branch)
+			     );
+   
+   rs_branch reserv_branch(
+			   //System
+			   .clk(clk),
+			   .reset(reset),
+			   .busyvec(busyvec_branch),
+			   .prmiss(prmiss),
+			   .prsuccess(prsuccess),
+			   .prtag(buf_spectag_branch),
+			   .specfixtag(spectagfix),
+			   .prbusyvec_next(prbusyvec_next_branch),
+			   //WriteSignal
+			   .clearbusy(issue_branch), //Issue 
+			   .issueaddr(issueent_branch), //= raddr, clsbsyadr
+			   .we1(~stall_DP & ~kill_DP & req1_branch), //alloc1
+			   .we2(~stall_DP & ~kill_DP & req2_branch), //alloc2
+			   .waddr1(allocent1_branch), //allocent1
+			   .waddr2(req1_branch ? 
+				   allocent2_branch : allocent1_branch), //allocent2
+			   //WriteSignal1
+			   .wpc_1(pc_id),
+			   .wsrc1_1(src1_1),
+			   .wsrc2_1(src2_1),
+			   .wvalid1_1(~uses_rs1_1_id | resolved1_1),
+			   .wvalid2_1(~uses_rs2_1_id | resolved2_1),
+			   .wimm_1(brimm1),
+			   .wrrftag_1(dst1_renamed),
+			   .wdstval_1(wr_reg_1_id),
+			   .walu_op_1(alu_op_1_id),
+			   .wspectag_1(sptag1_id),
+			   .wspecbit_1(spec1_id),
+			   .wbhr_1(bhr_id),
+			   .wprcond_1(prcond1_id),
+			   .wpraddr_1(praddr1_id),
+			   .wopcode_1(inst1_id[6:0]),
+			   //WriteSignal2
+			   .wpc_2(pc_id + 4),
+			   .wsrc1_2(src1_2),
+			   .wsrc2_2(src2_2),
+			   .wvalid1_2(~uses_rs1_2_id | resolved1_2),
+			   .wvalid2_2(~uses_rs2_2_id | resolved2_2),
+			   .wimm_2(brimm2),
+			   .wrrftag_2(dst2_renamed),
+			   .wdstval_2(wr_reg_2_id),
+			   .walu_op_2(alu_op_2_id),
+			   .wspectag_2(sptag2_id),
+			   .wspecbit_2(spec2_id),
+			   .wbhr_2(bhr_id),
+			   .wprcond_2(prcond2_id),
+			   .wpraddr_2(praddr2_id),
+			   .wopcode_2(inst2_id[6:0]),
+			   //ReadSignal
+			   .ex_src1(ex_src1_branch),
+			   .ex_src2(ex_src2_branch),
+			   .ready(ready_branch),
+			   .pc(pc_branch),
+			   .imm(imm_branch),
+			   .rrftag(rrftag_branch),
+			   .dstval(dstval_branch),
+			   .alu_op(alu_op_branch),
+			   .spectag(spectag_branch),
+			   .specbit(specbit_branch),
+			   .bhr(bhr_branch),
+			   .prcond(prcond_branch),
+			   .praddr(praddr_branch),
+			   .opcode(opcode_branch),
+			   //EXRSLT
+			   .exrslt1(result_alu1),
+			   .exdst1(buf_rrftag_alu1),
+			   .kill_spec1(kill_speculative_alu1 | ~robwe_alu1),
+			   .exrslt2(result_alu2),
+			   .exdst2(buf_rrftag_alu2),
+			   .kill_spec2(kill_speculative_alu2 | ~robwe_alu2),
+			   .exrslt3(result_ldst),
+			   .exdst3(wrrftag_ldst),
+			   .kill_spec3(kill_speculative_ldst | ~robwe_ldst),
+			   .exrslt4(result_branch),
+			   .exdst4(buf_rrftag_branch),
+			   .kill_spec4(~robwe_branch),
+			   .exrslt5(result_mul),
+			   .exdst5(buf_rrftag_mul),
+			   .kill_spec5(kill_speculative_mul | ~robwe_mul)
+			   );
+
+   assign issue_mul = ~prmiss & issuevalid_mul;
+
+   allocateunit #(`MUL_ENT_NUM, `MUL_ENT_SEL) alloc_mul(
+							.busy(busyvec_mul), //RS_BUSY
+							//      .en1(),
+							//      .en2(),
+							.free_ent1(allocent1_mul),
+							.free_ent2(allocent2_mul),
+							.reqnum(req_mulnum),
+							.allocatable(allocatable_mul)
+							);
+
+   prioenc #(`MUL_ENT_NUM, `MUL_ENT_SEL) isunt_mul(
+						   .in(~ready_mul),
+						   .out(issueent_mul),
+						   .en(issuevalid_mul)
+						   );
+   
+   rs_mul reserv_mul(
+		     //System
+		     .clk(clk),
+		     .reset(reset),
+		     .busyvec(busyvec_mul),
+		     .prmiss(prmiss),
+		     .prsuccess(prsuccess),
+		     .prtag(buf_spectag_branch),
+		     .specfixtag(spectagfix),
+		     //WriteSignal
+		     .clearbusy(issue_mul), //Issue 
+		     .issueaddr(issueent_mul), //= raddr, clsbsyadr
+		     .we1(~stall_DP & ~kill_DP & req1_mul), //alloc1
+		     .we2(~stall_DP & ~kill_DP & req2_mul), //alloc2
+		     .waddr1(allocent1_mul), //allocent1
+		     .waddr2(req1_mul ? 
+			     allocent2_mul : allocent1_mul), //allocent2
+		     //WriteSignal1
+		     .wsrc1_1(src1_1),
+		     .wsrc2_1(src2_1),
+		     .wvalid1_1(~uses_rs1_1_id | resolved1_1),
+		     .wvalid2_1(~uses_rs2_1_id | resolved2_1),
+		     .wrrftag_1(dst1_renamed),
+		     .wdstval_1(wr_reg_1_id),
+		     .wspectag_1(sptag1_id),
+		     .wspecbit_1(spec1_id),
+		     .wsrc1_signed_1(md_req_in_1_signed_1_id),
+		     .wsrc2_signed_1(md_req_in_2_signed_1_id),
+		     .wsel_lohi_1(md_req_out_sel_1_id[0]),
+		     //WriteSignal2
+		     .wsrc1_2(src1_2),
+		     .wsrc2_2(src2_2),
+		     .wvalid1_2(~uses_rs1_2_id | resolved1_2),
+		     .wvalid2_2(~uses_rs2_2_id | resolved2_2),
+		     .wrrftag_2(dst2_renamed),
+		     .wdstval_2(wr_reg_2_id),
+		     .wspectag_2(sptag2_id),
+		     .wspecbit_2(spec2_id),
+		     .wsrc1_signed_2(md_req_in_1_signed_2_id),
+		     .wsrc2_signed_2(md_req_in_2_signed_2_id),
+		     .wsel_lohi_2(md_req_out_sel_2_id[0]),
+		     //ReadSignal
+		     .ex_src1(ex_src1_mul),
+		     .ex_src2(ex_src2_mul),
+		     .ready(ready_mul),
+		     .rrftag(rrftag_mul),
+		     .dstval(dstval_mul),
+		     .spectag(spectag_mul),
+		     .specbit(specbit_mul),
+		     .src1_signed(src1_signed_mul),
+		     .src2_signed(src2_signed_mul),
+		     .sel_lohi(sel_lohi_mul),
+		     //EXRSLT
+		     .exrslt1(result_alu1),
+		     .exdst1(buf_rrftag_alu1),
+		     .kill_spec1(kill_speculative_alu1 | ~robwe_alu1),
+		     .exrslt2(result_alu2),
+		     .exdst2(buf_rrftag_alu2),
+		     .kill_spec2(kill_speculative_alu2 | ~robwe_alu2),
+		     .exrslt3(result_ldst),
+		     .exdst3(wrrftag_ldst),
+		     .kill_spec3(kill_speculative_ldst | ~robwe_ldst),
+		     .exrslt4(result_branch),
+		     .exdst4(buf_rrftag_branch),
+		     .kill_spec4(~robwe_branch),
+		     .exrslt5(result_mul),
+		     .exdst5(buf_rrftag_mul),
+		     .kill_spec5(kill_speculative_mul | ~robwe_mul)
+		     );
+   
+   //EX Stage********************************************************
+
+   always @ (posedge clk) begin
+      if (reset) begin
+	 buf_ex_src1_alu1 <= 0;
+	 buf_ex_src2_alu1 <= 0;
+	 buf_pc_alu1 <= 0;
+	 buf_imm_alu1 <= 0;
+	 buf_rrftag_alu1 <= 0;
+	 buf_dstval_alu1 <= 0;
+	 buf_src_a_alu1 <= 0;
+	 buf_src_b_alu1 <= 0;
+	 buf_alu_op_alu1 <= 0;
+	 buf_spectag_alu1 <= 0;
+	 buf_specbit_alu1 <= 0;
+      end else if (issue_alu1) begin
+	 buf_ex_src1_alu1 <= ex_src1_alu1;
+	 buf_ex_src2_alu1 <= ex_src2_alu1;
+	 buf_pc_alu1 <= pc_alu1;
+	 buf_imm_alu1 <= imm_alu1;
+	 buf_rrftag_alu1 <= rrftag_alu1;
+	 buf_dstval_alu1 <= dstval_alu1;
+	 buf_src_a_alu1 <= src_a_alu1;
+	 buf_src_b_alu1 <= src_b_alu1;
+	 buf_alu_op_alu1 <= alu_op_alu1;
+	 buf_spectag_alu1 <= spectag_alu1;
+	 buf_specbit_alu1 <= specbit_alu1;
+      end
+   end
+   
+   exunit_alu byakko(
+		     .clk(clk),
+		     .reset(reset),
+		     .ex_src1(buf_ex_src1_alu1),
+		     .ex_src2(buf_ex_src2_alu1),
+		     .pc(buf_pc_alu1),
+		     .imm(buf_imm_alu1),
+		     .dstval(buf_dstval_alu1),
+		     .src_a(buf_src_a_alu1),
+		     .src_b(buf_src_b_alu1),
+		     .alu_op(buf_alu_op_alu1),
+		     .spectag(buf_spectag_alu1),
+		     .specbit(buf_specbit_alu1),
+		     .issue(issue_alu1),
+		     .prmiss(prmiss),
+		     .spectagfix(spectagfix),
+		     .result(result_alu1),
+		     .rrf_we(rrfwe_alu1),
+		     .rob_we(robwe_alu1),
+		     .kill_speculative(kill_speculative_alu1)
+		     );
+
+   always @ (posedge clk) begin
+      if (reset) begin
+	 buf_ex_src1_alu2 <= 0;
+	 buf_ex_src2_alu2 <= 0;
+	 buf_pc_alu2 <= 0;
+	 buf_imm_alu2 <= 0;
+	 buf_rrftag_alu2 <= 0;
+	 buf_dstval_alu2 <= 0;
+	 buf_src_a_alu2 <= 0;
+	 buf_src_b_alu2 <= 0;
+	 buf_alu_op_alu2 <= 0;
+	 buf_spectag_alu2 <= 0;
+	 buf_specbit_alu2 <= 0;
+      end else if (issue_alu2) begin
+	 buf_ex_src1_alu2 <= ex_src1_alu2;
+	 buf_ex_src2_alu2 <= ex_src2_alu2;
+	 buf_pc_alu2 <= pc_alu2;
+	 buf_imm_alu2 <= imm_alu2;
+	 buf_rrftag_alu2 <= rrftag_alu2;
+	 buf_dstval_alu2 <= dstval_alu2;
+	 buf_src_a_alu2 <= src_a_alu2;
+	 buf_src_b_alu2 <= src_b_alu2;
+	 buf_alu_op_alu2 <= alu_op_alu2;
+	 buf_spectag_alu2 <= spectag_alu2;
+	 buf_specbit_alu2 <= specbit_alu2;
+      end
+   end
+   
+   exunit_alu suzaku(
+		     .clk(clk),
+		     .reset(reset),
+		     .ex_src1(buf_ex_src1_alu2),
+		     .ex_src2(buf_ex_src2_alu2),
+		     .pc(buf_pc_alu2),
+		     .imm(buf_imm_alu2),
+		     .dstval(buf_dstval_alu2),
+		     .src_a(buf_src_a_alu2),
+		     .src_b(buf_src_b_alu2),
+		     .alu_op(buf_alu_op_alu2),
+		     .spectag(buf_spectag_alu2),
+		     .specbit(buf_specbit_alu2),
+		     .issue(issue_alu2),
+		     .prmiss(prmiss),
+		     .spectagfix(spectagfix),
+		     .result(result_alu2),
+		     .rrf_we(rrfwe_alu2),
+		     .rob_we(robwe_alu2),
+		     .kill_speculative(kill_speculative_alu2)
+		     );
+
+   always @ (posedge clk) begin
+      if (reset) begin
+	 buf_ex_src1_ldst <= 0;
+	 buf_ex_src2_ldst <= 0;
+	 buf_pc_ldst <= 0;
+	 buf_imm_ldst <= 0;
+	 buf_rrftag_ldst <= 0;
+	 buf_dstval_ldst <= 0;
+	 buf_spectag_ldst <= 0;
+	 buf_specbit_ldst <= 0;
+      end else if (issue_ldst) begin
+	 buf_ex_src1_ldst <= ex_src1_ldst;
+	 buf_ex_src2_ldst <= ex_src2_ldst;
+	 buf_pc_ldst <= pc_ldst;
+	 buf_imm_ldst <= imm_ldst;
+	 buf_rrftag_ldst <= rrftag_ldst;
+	 buf_dstval_ldst <= dstval_ldst;
+	 buf_spectag_ldst <= spectag_ldst;
+	 buf_specbit_ldst <= specbit_ldst;
+      end
+   end // always @ (posedge clk)
+
+   assign dmem_addr = (memoccupy_ld) ? ldaddr : retaddr;
+
+/*   
+   dmem datamemory(
+		   .clk(clk),
+		   .addr({2'b0, dmem_addr[`ADDR_LEN-1:2]}),
+		   .wdata(dmem_wdata),
+		   .we(dmem_we),
+		   .rdata(dmem_data)
+		   );
+*/
+   storebuf sb
+     (
+      .clk(clk),
+      .reset(reset),
+      .prsuccess(prsuccess),
+      .prmiss(prmiss),
+      .prtag(buf_spectag_branch),
+      .spectagfix(spectagfix),
+      .stfin(stfin),
+      .stspecbit(buf_specbit_ldst),
+      .stspectag(buf_spectag_ldst),
+      .stdata(storedata),
+      .staddr(storeaddr),
+      .stcom(stcommit),
+      .stretire(dmem_we),
+      .retdata(dmem_wdata),
+      .retaddr(retaddr),
+      .memoccupy_ld(memoccupy_ld),
+      .sb_full(sb_full),
+      .ldaddr(ldaddr),
+      .lddata(lddatasb),
+      .hit(hitsb)
+      );
+
+   exunit_ldst seiryu(
+		      .clk(clk),
+		      .reset(reset),
+		      .ex_src1(buf_ex_src1_ldst),
+		      .ex_src2(buf_ex_src2_ldst),
+		      .pc(buf_pc_ldst),
+		      .imm(buf_imm_ldst),
+		      .dstval(buf_dstval_ldst),
+		      .spectag(buf_spectag_ldst),
+		      .specbit(buf_specbit_ldst),
+		      .rrftag(buf_rrftag_ldst),
+		      .issue(issue_ldst),
+		      .prmiss(prmiss),
+		      .spectagfix(spectagfix),
+		      .result(result_ldst),
+		      .rrf_we(rrfwe_ldst),
+		      .rob_we(robwe_ldst),
+		      .wrrftag(wrrftag_ldst),
+		      .kill_speculative(kill_speculative_ldst),
+		      .busy_next(busy_next_ldst),
+		      .stfin(stfin),
+		      .memoccupy_ld(memoccupy_ld),
+		      .fullsb(sb_full),
+		      .storedata(storedata),
+		      .storeaddr(storeaddr),
+		      .hitsb(hitsb),
+		      .ldaddr(ldaddr),
+		      .lddatasb(lddatasb),
+		      .lddatamem(dmem_data)
+		      );
+
+   always @ (posedge clk) begin
+      if (reset) begin
+	 buf_ex_src1_mul <= 0;
+	 buf_ex_src2_mul <= 0;
+	 buf_pc_mul <= 0;
+	 buf_rrftag_mul <= 0;
+	 buf_dstval_mul <= 0;
+	 buf_spectag_mul <= 0;
+	 buf_specbit_mul <= 0;
+	 buf_src1_signed_mul <= 0;
+	 buf_src2_signed_mul <= 0;
+	 buf_sel_lohi_mul <= 0;
+      end else if (issue_mul) begin
+	 buf_ex_src1_mul <= ex_src1_mul;
+	 buf_ex_src2_mul <= ex_src2_mul;
+	 buf_pc_mul <= pc_mul;
+	 buf_rrftag_mul <= rrftag_mul;
+	 buf_dstval_mul <= dstval_mul;
+	 buf_spectag_mul <= spectag_mul;
+	 buf_specbit_mul <= specbit_mul;
+	 buf_src1_signed_mul <= src1_signed_mul;
+	 buf_src2_signed_mul <= src2_signed_mul;
+	 buf_sel_lohi_mul <= sel_lohi_mul;
+      end
+   end
+   
+   exunit_mul genbu (
+		     .clk(clk),
+		     .reset(reset),
+		     .ex_src1(buf_ex_src1_mul),
+		     .ex_src2(buf_ex_src2_mul),
+		     .dstval(buf_dstval_mul),
+		     .spectag(buf_spectag_mul),
+		     .specbit(buf_specbit_mul),
+		     .src1_signed(buf_src1_signed_mul),
+		     .src2_signed(buf_src2_signed_mul),
+		     .sel_lohi(buf_sel_lohi_mul),
+		     .issue(issue_mul),
+		     .prmiss(prmiss),
+		     .spectagfix(spectagfix),
+		     .result(result_mul),
+		     .rrf_we(rrfwe_mul),
+		     .rob_we(robwe_mul),
+		     .kill_speculative(kill_speculative_mul)
+		     );
+
+
+   always @ (posedge clk) begin
+      if (reset) begin
+	 buf_ex_src1_branch <= 0;
+	 buf_ex_src2_branch <= 0;
+	 buf_pc_branch <= 0;
+	 buf_imm_branch <= 0;
+	 buf_rrftag_branch <= 0;
+	 buf_dstval_branch <= 0;
+	 buf_alu_op_branch <= 0;
+	 buf_spectag_branch <= 0;
+	 buf_specbit_branch <= 0;
+	 buf_praddr_branch <= 0;
+	 buf_opcode_branch <= 0;
+      end else if (issue_branch) begin
+	 buf_ex_src1_branch <= ex_src1_branch;
+	 buf_ex_src2_branch <= ex_src2_branch;
+	 buf_pc_branch <= pc_branch;
+	 buf_imm_branch <= imm_branch;
+	 buf_rrftag_branch <= rrftag_branch;
+	 buf_dstval_branch <= dstval_branch;
+	 buf_alu_op_branch <= alu_op_branch;
+	 buf_spectag_branch <= spectag_branch;
+	 buf_specbit_branch <= specbit_branch;
+	 buf_praddr_branch <= praddr_branch;
+	 buf_opcode_branch <= opcode_branch;
+      end
+   end
+   
+   exunit_branch kirin(
+		       .clk(clk),
+		       .reset(reset),
+		       .ex_src1(buf_ex_src1_branch),
+		       .ex_src2(buf_ex_src2_branch),
+		       .pc(buf_pc_branch),
+		       .imm(buf_imm_branch),
+		       .dstval(buf_dstval_branch),
+		       .alu_op(buf_alu_op_branch),
+		       .spectag(buf_spectag_branch),
+		       .specbit(buf_specbit_branch),
+		       .praddr(buf_praddr_branch),
+		       .opcode(buf_opcode_branch),
+		       .issue(issue_branch),
+		       .result(result_branch),
+		       .rrf_we(rrfwe_branch),
+		       .rob_we(robwe_branch),
+		       .prsuccess(prsuccess),
+		       .prmiss(prmiss),
+		       .jmpaddr(jmpaddr),
+		       .jmpaddr_taken(jmpaddr_taken),
+		       .brcond(brcond),
+		       .tagregfix(tagregfix)
+		       );
+
+   
+   miss_prediction_fix_table mpft(
+				  .clk(clk),
+				  .reset(reset),
+				  .mpft_valid(mpft_valid),
+				  .value_addr(buf_spectag_branch),
+				  .mpft_value(spectagfix),
+				  .prmiss(prmiss),
+				  .prsuccess(prsuccess),
+				  .prsuccess_tag(buf_spectag_branch),
+				  .setspec1_tag(sptag1),
+				  .setspec1_en(isbranch1 & ~stall_ID & ~stall_DP),
+				  .setspec2_tag(sptag2),
+				  .setspec2_en(branchvalid2 & ~stall_ID & ~stall_DP)
+				  );
+   
+   //COM Stage*******************************************************
+   reorderbuf rob(
+		  .clk(clk),
+		  .reset(reset),
+		  .dp1(~stall_DP & ~kill_DP & ~inv1_id),
+		  .dp1_addr(dst1_renamed),
+		  .pc_dp1(pc_id),
+		  .storebit_dp1(inst1_id[6:0] == `RV32_STORE ? 1'b1 : 1'b0),
+		  .dstvalid_dp1(wr_reg_1_id),
+		  .dst_dp1(rd_1_id),
+		  .bhr_dp1(bhr_id),
+		  .isbranch_dp1(req1_branch),
+		  .dp2(~stall_DP & ~kill_DP & ~inv2_id),
+		  .dp2_addr(dst2_renamed),
+		  .pc_dp2(pc_id + 4),
+		  .storebit_dp2(inst2_id[6:0] == `RV32_STORE ? 1'b1 : 1'b0),
+		  .dstvalid_dp2(wr_reg_2_id),
+		  .dst_dp2(rd_2_id),
+		  .bhr_dp2(bhr_id),
+		  .isbranch_dp2(req2_branch),
+		  .exfin_alu1(robwe_alu1),
+		  .exfin_alu1_addr(buf_rrftag_alu1),
+		  .exfin_alu2(robwe_alu2),
+		  .exfin_alu2_addr(buf_rrftag_alu2),
+		  .exfin_mul(robwe_mul),
+		  .exfin_mul_addr(buf_rrftag_mul),
+		  .exfin_ldst(robwe_ldst),
+		  .exfin_ldst_addr(wrrftag_ldst),
+		  .exfin_branch(robwe_branch),
+		  .exfin_branch_addr(buf_rrftag_branch),
+		  .exfin_branch_brcond(brcond),
+		  .exfin_branch_jmpaddr(jmpaddr_taken),
+
+		  .comptr(comptr),
+		  .comptr2(comptr2),
+		  .comnum(comnum),
+		  .stcommit(stcommit),
+		  .arfwe1(arfwe1),
+		  .arfwe2(arfwe2),
+		  .dstarf1(dstarf1),
+		  .dstarf2(dstarf2),
+		  .pc_combranch(pc_combranch),
+		  .bhr_combranch(bhr_combranch),
+		  .brcond_combranch(brcond_combranch),
+		  .jmpaddr_combranch(jmpaddr_combranch),
+		  .combranch(combranch),
+		  .dispatchptr(rrfptr),
+		  .rrf_freenum(freenum),
+		  .prmiss(prmiss)
+		  );
+
+  
+endmodule // pipeline
+
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/pipeline_if.v
+++ b/examples/SQED_ridecore/rtl/design/pipeline_if.v
@@ -1,0 +1,129 @@
+`include "constants.vh"
+`default_nettype none
+module pipeline_if
+  (
+   input wire 			  clk,
+   input wire 			  reset,
+   input wire [`ADDR_LEN-1:0] 	  pc,
+   output wire 			  predict_cond,
+   output wire [`ADDR_LEN-1:0] 	  npc,
+   output wire [`INSN_LEN-1:0] 	  inst1,
+   output wire [`INSN_LEN-1:0] 	  inst2,
+   output wire 			  invalid2,
+   input wire 			  btbpht_we,
+   input wire [`ADDR_LEN-1:0] 	  btbpht_pc,
+   input wire [`ADDR_LEN-1:0] 	  btb_jmpdst,
+   input wire 			  pht_wcond,
+   input wire [`SPECTAG_LEN-1:0]  mpft_valid,
+   input wire [`GSH_BHR_LEN-1:0]  pht_bhr,
+   input wire 			  prmiss,
+   input wire 			  prsuccess,
+   input wire [`SPECTAG_LEN-1:0]  prtag,
+   output wire [`GSH_BHR_LEN-1:0] bhr,
+   input wire [`SPECTAG_LEN-1:0]  spectagnow,
+   input wire [4*`INSN_LEN-1:0]   idata
+   );
+
+   wire 			  hit;
+   wire [`ADDR_LEN-1:0] 	  pred_pc;
+
+   assign npc = (hit && predict_cond) ? pred_pc : invalid2 ? pc + 4 : pc + 8;
+/*   
+   imem instmem(
+		.clk(~clk),
+		.addr(pc[12:4]),
+		.data(idata)
+		);
+*/
+   /*
+   imem_outa instmem(
+		     .pc(pc[31:4]),
+		     .idata(idata)
+		     );
+   */
+   select_logic sellog(
+		       .sel(pc[3:2]),
+		       .idata(idata),
+		       .inst1(inst1),
+		       .inst2(inst2),
+		       .invalid(invalid2)
+		       );
+
+   /* EDIT: remove branch target buffer to get rid of neg-edge behavior
+   btb brtbl(
+	     .clk(clk),
+	     .reset(reset),
+	     .pc(pc),
+	     .hit(hit),
+	     .jmpaddr(pred_pc),
+	     .we(btbpht_we),
+	     .jmpsrc(btbpht_pc),
+	     .jmpdst(btb_jmpdst),
+	     .invalid2(invalid2)
+	     );
+    */
+    
+   // EDIT: manually cut predict_cond and bhr and assign it to 0
+   assign predict_cond = 1'b0;
+   assign bhr = 1'b0;
+   wire                                     cut_predict_cond;
+   wire [`GSH_BHR_LEN-1:0]                  cut_bhr;
+   gshare_predictor gsh
+     (
+      .clk(clk),
+      .reset(reset),
+      .pc(pc),
+      .hit_bht(hit),
+      .predict_cond(cut_predict_cond),
+      .we(btbpht_we),
+      .wcond(pht_wcond),
+      .went(btbpht_pc[2+:`GSH_BHR_LEN] ^ pht_bhr),
+      .mpft_valid(mpft_valid),
+      .prmiss(prmiss),
+      .prsuccess(prsuccess),
+      .prtag(prtag),
+      .bhr_master(cut_bhr),
+      .spectagnow(spectagnow)
+      );
+   
+endmodule // pipeline_pc
+
+
+module select_logic
+  (
+   input wire [1:0] 		sel,
+   input wire [4*`INSN_LEN-1:0] idata,
+   output reg [`INSN_LEN-1:0] 	inst1,
+   output reg [`INSN_LEN-1:0] 	inst2,
+   output wire 			invalid
+   );
+
+   assign invalid = (sel[0] == 1'b1);
+   
+   always @ (*) begin
+      inst1 = `INSN_LEN'h0;
+      inst2 = `INSN_LEN'h0;
+      
+      case(sel)
+	2'b00 : begin
+	   inst1 = idata[31:0];
+	   inst2 = idata[63:32];
+	end
+	2'b01 : begin
+	   inst1 = idata[63:32];
+	   inst2 = idata[95:64];
+	end
+	2'b10 : begin
+	   inst1 = idata[95:64];
+	   inst2 = idata[127:96];
+	end
+	2'b11 : begin
+	   inst1 = idata[127:96];
+	   inst2 = idata[31:0];
+	end
+      endcase // case (sel)
+   end
+   
+endmodule // select_logic
+
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/prioenc.v
+++ b/examples/SQED_ridecore/rtl/design/prioenc.v
@@ -1,0 +1,83 @@
+`default_nettype none
+module prioenc #(
+		 parameter REQ_LEN = 4,
+		 parameter GRANT_LEN = 2
+		 )
+   (
+    input wire [REQ_LEN-1:0]   in,
+    output reg [GRANT_LEN-1:0] out,
+    output reg 		       en
+   );
+   
+   integer 		      i;
+   always @ (*) begin
+      en = 0;
+      out = 0;
+      for (i = REQ_LEN-1 ; i >= 0 ; i = i - 1) begin
+	 if (~in[i]) begin
+	    out = i;
+	    en = 1;
+	 end
+      end
+   end
+endmodule
+
+module maskunit  #(
+		   parameter REQ_LEN = 4,
+		   parameter GRANT_LEN = 2
+		   )
+   (
+    input wire [GRANT_LEN-1:0] mask,
+    input wire [REQ_LEN-1:0]   in,
+    output reg [REQ_LEN-1:0]   out
+   );
+   
+   integer 		      i;
+   always @ (*) begin
+      out = 0;
+      for (i = 0 ; i < REQ_LEN ; i = i+1) begin
+	 out[i] = (mask < i) ? 1'b0 : 1'b1;
+      end
+   end
+endmodule
+
+module allocateunit  #(
+		       parameter REQ_LEN = 4,
+		       parameter GRANT_LEN = 2
+		       )
+   (
+    input wire [REQ_LEN-1:0] 	busy,
+    output wire 		en1,
+    output wire 		en2,
+    output wire [GRANT_LEN-1:0] free_ent1,
+    output wire [GRANT_LEN-1:0] free_ent2,
+    input wire [1:0] 		reqnum,
+    output wire 		allocatable
+   );
+   
+   wire [REQ_LEN-1:0] 	       busy_msk;
+   
+   prioenc #(REQ_LEN, GRANT_LEN) p1
+     (
+      .in(busy),
+      .out(free_ent1),
+      .en(en1)
+      );
+
+   maskunit #(REQ_LEN, GRANT_LEN) msku
+     (
+      .mask(free_ent1),
+      .in(busy),
+      .out(busy_msk)
+      );
+   
+   prioenc #(REQ_LEN, GRANT_LEN) p2
+     (
+      .in(busy | busy_msk),
+      .out(free_ent2),
+      .en(en2)
+      );
+
+   assign allocatable = (reqnum > ({1'b0,en1}+{1'b0,en2})) ? 1'b0 : 1'b1;
+endmodule
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/ram_sync.v
+++ b/examples/SQED_ridecore/rtl/design/ram_sync.v
@@ -1,0 +1,264 @@
+`include "constants.vh"
+`default_nettype none
+module ram_sync_1r1w #(
+		       parameter BRAM_ADDR_WIDTH = `ADDR_LEN,
+		       parameter BRAM_DATA_WIDTH = `DATA_LEN,
+		       parameter DATA_DEPTH      = 32
+		       ) 
+   (
+    input wire 			     clk,
+    input wire [BRAM_ADDR_WIDTH-1:0] raddr1,
+    output reg [BRAM_DATA_WIDTH-1:0] rdata1,
+    input wire [BRAM_ADDR_WIDTH-1:0] waddr,
+    input wire [BRAM_DATA_WIDTH-1:0] wdata,
+    input wire 			     we
+    );
+
+   reg [BRAM_DATA_WIDTH-1:0] 			      mem [0:DATA_DEPTH-1];
+
+   always @ (posedge clk) begin
+      rdata1 <= mem[raddr1];
+      if (we)
+	mem[waddr] <= wdata;
+   end
+endmodule // ram_sync_1r1w
+
+module ram_sync_2r1w #(
+		       parameter BRAM_ADDR_WIDTH = `ADDR_LEN,
+		       parameter BRAM_DATA_WIDTH = `DATA_LEN,
+		       parameter DATA_DEPTH      = 32
+		       ) 
+   (
+    input wire 			     clk,
+    input wire [BRAM_ADDR_WIDTH-1:0] raddr1,
+    input wire [BRAM_ADDR_WIDTH-1:0] raddr2,
+    output reg [BRAM_DATA_WIDTH-1:0] rdata1,
+    output reg [BRAM_DATA_WIDTH-1:0] rdata2,
+    input wire [BRAM_ADDR_WIDTH-1:0] waddr,
+    input wire [BRAM_DATA_WIDTH-1:0] wdata,
+    input wire 			     we
+    );
+   
+   reg [BRAM_DATA_WIDTH-1:0] 			      mem [0:DATA_DEPTH-1];
+
+   always @ (posedge clk) begin
+      rdata1 <= mem[raddr1];
+      rdata2 <= mem[raddr2];
+      if (we)
+	mem[waddr] <= wdata;
+   end
+endmodule // ram_sync_2r1w
+
+module ram_sync_2r2w #(
+		       parameter BRAM_ADDR_WIDTH = `ADDR_LEN,
+		       parameter BRAM_DATA_WIDTH = `DATA_LEN,
+		       parameter DATA_DEPTH      = 32
+		       ) 
+   (
+    input wire 			     clk,
+    input wire [BRAM_ADDR_WIDTH-1:0] raddr1,
+    input wire [BRAM_ADDR_WIDTH-1:0] raddr2,
+    output reg [BRAM_DATA_WIDTH-1:0] rdata1,
+    output reg [BRAM_DATA_WIDTH-1:0] rdata2,
+    input wire [BRAM_ADDR_WIDTH-1:0] waddr1,
+    input wire [BRAM_ADDR_WIDTH-1:0] waddr2,
+    input wire [BRAM_DATA_WIDTH-1:0] wdata1,
+    input wire [BRAM_DATA_WIDTH-1:0] wdata2,
+    input wire 			     we1,
+    input wire 			     we2
+    );
+   
+   reg [BRAM_DATA_WIDTH-1:0] 			      mem [0:DATA_DEPTH-1];
+
+   always @ (posedge clk) begin
+      rdata1 <= mem[raddr1];
+      rdata2 <= mem[raddr2];
+      if (we1)
+	mem[waddr1] <= wdata1;
+      if (we2)
+	mem[waddr2] <= wdata2;
+   end
+endmodule // ram_sync_2r2w
+
+module ram_sync_4r1w #(
+		       parameter BRAM_ADDR_WIDTH = `ADDR_LEN,
+		       parameter BRAM_DATA_WIDTH = `DATA_LEN,
+		       parameter DATA_DEPTH      = 32
+		       ) 
+   (
+    input wire 			      clk,
+    input wire [BRAM_ADDR_WIDTH-1:0]  raddr1,
+    input wire [BRAM_ADDR_WIDTH-1:0]  raddr2,
+    input wire [BRAM_ADDR_WIDTH-1:0]  raddr3,
+    input wire [BRAM_ADDR_WIDTH-1:0]  raddr4,
+    output wire [BRAM_DATA_WIDTH-1:0] rdata1,
+    output wire [BRAM_DATA_WIDTH-1:0] rdata2,
+    output wire [BRAM_DATA_WIDTH-1:0] rdata3,
+    output wire [BRAM_DATA_WIDTH-1:0] rdata4,
+    input wire [BRAM_ADDR_WIDTH-1:0]  waddr,
+    input wire [BRAM_DATA_WIDTH-1:0]  wdata,
+    input wire 			      we
+    );
+   
+   ram_sync_2r1w 
+     #(BRAM_ADDR_WIDTH, BRAM_DATA_WIDTH, DATA_DEPTH) 
+   mem0(
+	.clk(clk),
+	.raddr1(raddr1),
+	.raddr2(raddr2),
+	.rdata1(rdata1),
+	.rdata2(rdata2),
+	.waddr(waddr),
+	.wdata(wdata),
+	.we(we)
+	);
+
+   ram_sync_2r1w 
+     #(BRAM_ADDR_WIDTH, BRAM_DATA_WIDTH, DATA_DEPTH) 
+   mem1(
+	.clk(clk),
+	.raddr1(raddr3),
+	.raddr2(raddr4),
+	.rdata1(rdata3),
+	.rdata2(rdata4),
+	.waddr(waddr),
+	.wdata(wdata),
+	.we(we)
+	);
+   
+endmodule // ram_sync_4r1w
+
+module ram_sync_4r2w #(
+		       parameter BRAM_ADDR_WIDTH = `ADDR_LEN,
+		       parameter BRAM_DATA_WIDTH = `DATA_LEN,
+		       parameter DATA_DEPTH      = 32
+		       ) 
+   (
+    input wire 			      clk,
+    input wire [BRAM_ADDR_WIDTH-1:0]  raddr1,
+    input wire [BRAM_ADDR_WIDTH-1:0]  raddr2,
+    input wire [BRAM_ADDR_WIDTH-1:0]  raddr3,
+    input wire [BRAM_ADDR_WIDTH-1:0]  raddr4,
+    output wire [BRAM_DATA_WIDTH-1:0] rdata1,
+    output wire [BRAM_DATA_WIDTH-1:0] rdata2,
+    output wire [BRAM_DATA_WIDTH-1:0] rdata3,
+    output wire [BRAM_DATA_WIDTH-1:0] rdata4,
+    input wire [BRAM_ADDR_WIDTH-1:0]  waddr1,
+    input wire [BRAM_ADDR_WIDTH-1:0]  waddr2,
+    input wire [BRAM_DATA_WIDTH-1:0]  wdata1,
+    input wire [BRAM_DATA_WIDTH-1:0]  wdata2,
+    input wire 			      we1,
+    input wire 			      we2
+    );
+
+   ram_sync_2r2w 
+     #(BRAM_ADDR_WIDTH, BRAM_DATA_WIDTH, DATA_DEPTH) 
+   mem0(
+	.clk(clk),
+	.raddr1(raddr1),
+	.raddr2(raddr2),
+	.rdata1(rdata1),
+	.rdata2(rdata2),
+	.waddr1(waddr1),
+	.waddr2(waddr2),
+	.wdata1(wdata1),
+	.wdata2(wdata2),
+	.we1(we1),
+	.we2(we2)
+	);
+
+   ram_sync_2r2w 
+     #(BRAM_ADDR_WIDTH, BRAM_DATA_WIDTH, DATA_DEPTH) 
+   mem1(
+	.clk(clk),
+	.raddr1(raddr3),
+	.raddr2(raddr4),
+	.rdata1(rdata3),
+	.rdata2(rdata4),
+	.waddr1(waddr1),
+	.waddr2(waddr2),
+	.wdata1(wdata1),
+	.wdata2(wdata2),
+	.we1(we1),
+	.we2(we2)
+	);
+   
+endmodule // ram_sync_4r2w
+
+module ram_sync_6r2w #(
+		       parameter BRAM_ADDR_WIDTH = `ADDR_LEN,
+		       parameter BRAM_DATA_WIDTH = `DATA_LEN,
+		       parameter DATA_DEPTH      = 32
+		       ) 
+   (
+    input wire 			      clk,
+    input wire [BRAM_ADDR_WIDTH-1:0]  raddr1,
+    input wire [BRAM_ADDR_WIDTH-1:0]  raddr2,
+    input wire [BRAM_ADDR_WIDTH-1:0]  raddr3,
+    input wire [BRAM_ADDR_WIDTH-1:0]  raddr4,
+    input wire [BRAM_ADDR_WIDTH-1:0]  raddr5,
+    input wire [BRAM_ADDR_WIDTH-1:0]  raddr6,
+    output wire [BRAM_DATA_WIDTH-1:0] rdata1,
+    output wire [BRAM_DATA_WIDTH-1:0] rdata2,
+    output wire [BRAM_DATA_WIDTH-1:0] rdata3,
+    output wire [BRAM_DATA_WIDTH-1:0] rdata4,
+    output wire [BRAM_DATA_WIDTH-1:0] rdata5,
+    output wire [BRAM_DATA_WIDTH-1:0] rdata6,
+    input wire [BRAM_ADDR_WIDTH-1:0]  waddr1,
+    input wire [BRAM_ADDR_WIDTH-1:0]  waddr2,
+    input wire [BRAM_DATA_WIDTH-1:0]  wdata1,
+    input wire [BRAM_DATA_WIDTH-1:0]  wdata2,
+    input wire 			      we1,
+    input wire 			      we2
+    );
+
+   ram_sync_2r2w 
+     #(BRAM_ADDR_WIDTH, BRAM_DATA_WIDTH, DATA_DEPTH) 
+   mem0(
+	.clk(clk),
+	.raddr1(raddr1),
+	.raddr2(raddr2),
+	.rdata1(rdata1),
+	.rdata2(rdata2),
+	.waddr1(waddr1),
+	.waddr2(waddr2),
+	.wdata1(wdata1),
+	.wdata2(wdata2),
+	.we1(we1),
+	.we2(we2)
+	);
+
+   ram_sync_2r2w 
+     #(BRAM_ADDR_WIDTH, BRAM_DATA_WIDTH, DATA_DEPTH) 
+   mem1(
+	.clk(clk),
+	.raddr1(raddr3),
+	.raddr2(raddr4),
+	.rdata1(rdata3),
+	.rdata2(rdata4),
+	.waddr1(waddr1),
+	.waddr2(waddr2),
+	.wdata1(wdata1),
+	.wdata2(wdata2),
+	.we1(we1),
+	.we2(we2)
+	);
+
+   ram_sync_2r2w 
+     #(BRAM_ADDR_WIDTH, BRAM_DATA_WIDTH, DATA_DEPTH) 
+   mem2(
+	.clk(clk),
+	.raddr1(raddr5),
+	.raddr2(raddr6),
+	.rdata1(rdata5),
+	.rdata2(rdata6),
+	.waddr1(waddr1),
+	.waddr2(waddr2),
+	.wdata1(wdata1),
+	.wdata2(wdata2),
+	.we1(we1),
+	.we2(we2)
+	);
+   
+endmodule // ram_sync_6r2w
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/ram_sync_nolatch.v
+++ b/examples/SQED_ridecore/rtl/design/ram_sync_nolatch.v
@@ -1,0 +1,292 @@
+`include "constants.vh"
+`default_nettype none
+module ram_sync_nolatch_2r1w #(
+			       parameter BRAM_ADDR_WIDTH = `ADDR_LEN,
+			       parameter BRAM_DATA_WIDTH = `DATA_LEN,
+			       parameter DATA_DEPTH      = 32
+			       ) 
+   (
+    input wire 			      clk,
+    input wire [BRAM_ADDR_WIDTH-1:0]  raddr1,
+    input wire [BRAM_ADDR_WIDTH-1:0]  raddr2,
+    output wire [BRAM_DATA_WIDTH-1:0] rdata1,
+    output wire [BRAM_DATA_WIDTH-1:0] rdata2,
+    input wire [BRAM_ADDR_WIDTH-1:0]  waddr,
+    input wire [BRAM_DATA_WIDTH-1:0]  wdata,
+    input wire 			      we
+    );
+   
+   reg [BRAM_DATA_WIDTH-1:0] 				       mem [0:DATA_DEPTH-1];
+
+   integer 						       i;
+   
+   assign rdata1 = mem[raddr1];
+   assign rdata2 = mem[raddr2];
+   
+   always @ (posedge clk) begin
+      if (we)
+	mem[waddr] <= wdata;
+   end
+endmodule // ram_sync_nolatch_2r1w
+
+module ram_sync_nolatch_2r2w #(
+			       parameter BRAM_ADDR_WIDTH = `ADDR_LEN,
+			       parameter BRAM_DATA_WIDTH = `DATA_LEN,
+			       parameter DATA_DEPTH      = 32
+			       ) 
+   (
+    input wire 			      clk,
+    input wire [BRAM_ADDR_WIDTH-1:0]  raddr1,
+    input wire [BRAM_ADDR_WIDTH-1:0]  raddr2,
+    output wire [BRAM_DATA_WIDTH-1:0] rdata1,
+    output wire [BRAM_DATA_WIDTH-1:0] rdata2,
+    input wire [BRAM_ADDR_WIDTH-1:0]  waddr1,
+    input wire [BRAM_ADDR_WIDTH-1:0]  waddr2,
+    input wire [BRAM_DATA_WIDTH-1:0]  wdata1,
+    input wire [BRAM_DATA_WIDTH-1:0]  wdata2,
+    input wire 			      we1,
+    input wire 			      we2
+    );
+   
+   reg [BRAM_DATA_WIDTH-1:0] 				       mem [0:DATA_DEPTH-1];
+
+   assign rdata1 = mem[raddr1];
+   assign rdata2 = mem[raddr2];
+   
+   always @ (posedge clk) begin
+      if (we1)
+	mem[waddr1] <= wdata1;
+      if (we2)
+	mem[waddr2] <= wdata2;
+   end
+endmodule // ram_sync_nolatch_2r2w
+
+/*
+ module ram_sync_nolatch_4r1w(
+ input wire 			       clk,
+ input wire [BRAM_ADDR_WIDTH-1:0]       raddr1,
+ input wire [BRAM_ADDR_WIDTH-1:0]       raddr2,
+ input wire [BRAM_ADDR_WIDTH-1:0]       raddr3,
+ input wire [BRAM_ADDR_WIDTH-1:0]       raddr4,
+ output wire [BRAM_DATA_WIDTH-1:0] rdata1,
+ output wire [BRAM_DATA_WIDTH-1:0] rdata2,
+ output wire [BRAM_DATA_WIDTH-1:0] rdata3,
+ output wire [BRAM_DATA_WIDTH-1:0] rdata4,
+ input wire [BRAM_ADDR_WIDTH-1:0]       waddr,
+ input wire [BRAM_DATA_WIDTH-1:0]       wdata,
+ input wire 			       we
+ );
+ parameter BRAM_ADDR_WIDTH = `ADDR_LEN;
+ parameter BRAM_DATA_WIDTH = `DATA_LEN;
+ parameter DATA_DEPTH      = 32;
+
+ ram_sync_nolatch_2r1w 
+ #(BRAM_ADDR_WIDTH, BRAM_DATA_WIDTH, DATA_DEPTH) 
+ mem0(
+ .clk(clk),
+ .raddr1(raddr1),
+ .raddr2(raddr2),
+ .rdata1(rdata1),
+ .rdata2(rdata2),
+ .waddr(waddr),
+ .wdata(wdata),
+ .we(we)
+ );
+
+ ram_sync_nolatch_2r1w 
+ #(BRAM_ADDR_WIDTH, BRAM_DATA_WIDTH, DATA_DEPTH) 
+ mem1(
+ .clk(clk),
+ .raddr1(raddr3),
+ .raddr2(raddr4),
+ .rdata1(rdata3),
+ .rdata2(rdata4),
+ .waddr(waddr),
+ .wdata(wdata),
+ .we(we)
+ );
+ 
+ endmodule //ram_sync_nolatch_4r1w
+ */
+module ram_sync_nolatch_4r2w #(
+			       parameter BRAM_ADDR_WIDTH = `ADDR_LEN,
+			       parameter BRAM_DATA_WIDTH = `DATA_LEN,
+			       parameter DATA_DEPTH      = 32
+			       ) 
+   (
+    input wire 			      clk,
+    input wire [BRAM_ADDR_WIDTH-1:0]  raddr1,
+    input wire [BRAM_ADDR_WIDTH-1:0]  raddr2,
+    input wire [BRAM_ADDR_WIDTH-1:0]  raddr3,
+    input wire [BRAM_ADDR_WIDTH-1:0]  raddr4,
+    output wire [BRAM_DATA_WIDTH-1:0] rdata1,
+    output wire [BRAM_DATA_WIDTH-1:0] rdata2,
+    output wire [BRAM_DATA_WIDTH-1:0] rdata3,
+    output wire [BRAM_DATA_WIDTH-1:0] rdata4,
+    input wire [BRAM_ADDR_WIDTH-1:0]  waddr1,
+    input wire [BRAM_ADDR_WIDTH-1:0]  waddr2,
+    input wire [BRAM_DATA_WIDTH-1:0]  wdata1,
+    input wire [BRAM_DATA_WIDTH-1:0]  wdata2,
+    input wire 			      we1,
+    input wire 			      we2,
+    output wire [BRAM_DATA_WIDTH-1:0] mem0,
+    output wire [BRAM_DATA_WIDTH-1:0] mem1,
+    output wire [BRAM_DATA_WIDTH-1:0] mem2,
+    output wire [BRAM_DATA_WIDTH-1:0] mem3,
+    output wire [BRAM_DATA_WIDTH-1:0] mem4,
+    output wire [BRAM_DATA_WIDTH-1:0] mem5,
+    output wire [BRAM_DATA_WIDTH-1:0] mem6,
+    output wire [BRAM_DATA_WIDTH-1:0] mem7,
+    output wire [BRAM_DATA_WIDTH-1:0] mem8,
+    output wire [BRAM_DATA_WIDTH-1:0] mem9,
+    output wire [BRAM_DATA_WIDTH-1:0] mem10,
+    output wire [BRAM_DATA_WIDTH-1:0] mem11,
+    output wire [BRAM_DATA_WIDTH-1:0] mem12,
+    output wire [BRAM_DATA_WIDTH-1:0] mem13,
+    output wire [BRAM_DATA_WIDTH-1:0] mem14,
+    output wire [BRAM_DATA_WIDTH-1:0] mem15,
+    output wire [BRAM_DATA_WIDTH-1:0] mem16,
+    output wire [BRAM_DATA_WIDTH-1:0] mem17,
+    output wire [BRAM_DATA_WIDTH-1:0] mem18,
+    output wire [BRAM_DATA_WIDTH-1:0] mem19,
+    output wire [BRAM_DATA_WIDTH-1:0] mem20,
+    output wire [BRAM_DATA_WIDTH-1:0] mem21,
+    output wire [BRAM_DATA_WIDTH-1:0] mem22,
+    output wire [BRAM_DATA_WIDTH-1:0] mem23,
+    output wire [BRAM_DATA_WIDTH-1:0] mem24,
+    output wire [BRAM_DATA_WIDTH-1:0] mem25,
+    output wire [BRAM_DATA_WIDTH-1:0] mem26,
+    output wire [BRAM_DATA_WIDTH-1:0] mem27,
+    output wire [BRAM_DATA_WIDTH-1:0] mem28,
+    output wire [BRAM_DATA_WIDTH-1:0] mem29,
+    output wire [BRAM_DATA_WIDTH-1:0] mem30,
+    output wire [BRAM_DATA_WIDTH-1:0] mem31
+    );
+
+   reg [BRAM_DATA_WIDTH-1:0] 				       mem [0:DATA_DEPTH-1];
+   
+   //Mutation Testing: The value of the next register read is corrupted to all 0's
+   assign rdata1 = mem[raddr1];
+   //assign rdata1 = BRAM_DATA_WIDTH'd0;
+   assign rdata2 = mem[raddr2];
+   assign rdata3 = mem[raddr3];
+   assign rdata4 = mem[raddr4];
+   
+   always @ (posedge clk) begin
+      if (we1)
+	      mem[waddr1] <= wdata1;
+      if (we2)
+	      mem[waddr2] <= wdata2;
+   end
+
+   assign mem0 = mem[0];
+   assign mem1 = mem[1];
+   assign mem2 = mem[2];
+   assign mem3 = mem[3];
+   assign mem4 = mem[4];
+   assign mem5 = mem[5];
+   assign mem6 = mem[6];
+   assign mem7 = mem[7];
+   assign mem8 = mem[8];
+   assign mem9 = mem[9];
+   assign mem10 = mem[10];
+   assign mem11 = mem[11];
+   assign mem12 = mem[12];
+   assign mem13 = mem[13];
+   assign mem14 = mem[14];
+   assign mem15 = mem[15];
+   assign mem16 = mem[16];
+   assign mem17 = mem[17];
+   assign mem18 = mem[18];
+   assign mem19 = mem[19];
+   assign mem20 = mem[20];
+   assign mem21 = mem[21];
+   assign mem22 = mem[22];
+   assign mem23 = mem[23];
+   assign mem24 = mem[24];
+   assign mem25 = mem[25];
+   assign mem26 = mem[26];
+   assign mem27 = mem[27];
+   assign mem28 = mem[28];
+   assign mem29 = mem[29];
+   assign mem30 = mem[30];
+   assign mem31 = mem[31];
+endmodule // ram_sync_nolatch_4r2w
+
+/*
+ module ram_sync_nolatch_6r2w(
+ input wire 			       clk,
+ input wire [BRAM_ADDR_WIDTH-1:0]       raddr1,
+ input wire [BRAM_ADDR_WIDTH-1:0]       raddr2,
+ input wire [BRAM_ADDR_WIDTH-1:0]       raddr3,
+ input wire [BRAM_ADDR_WIDTH-1:0]       raddr4,
+ input wire [BRAM_ADDR_WIDTH-1:0]       raddr5,
+ input wire [BRAM_ADDR_WIDTH-1:0]       raddr6,
+ output wire [BRAM_DATA_WIDTH-1:0] rdata1,
+ output wire [BRAM_DATA_WIDTH-1:0] rdata2,
+ output wire [BRAM_DATA_WIDTH-1:0] rdata3,
+ output wire [BRAM_DATA_WIDTH-1:0] rdata4,
+ output wire [BRAM_DATA_WIDTH-1:0] rdata5,
+ output wire [BRAM_DATA_WIDTH-1:0] rdata6,
+ input wire [BRAM_ADDR_WIDTH-1:0]       waddr1,
+ input wire [BRAM_ADDR_WIDTH-1:0]       waddr2,
+ input wire [BRAM_DATA_WIDTH-1:0]       wdata1,
+ input wire [BRAM_DATA_WIDTH-1:0]       wdata2,
+ input wire 			       we1,
+ input wire 			       we2
+ );
+ parameter BRAM_ADDR_WIDTH = `ADDR_LEN;
+ parameter BRAM_DATA_WIDTH = `DATA_LEN;
+ parameter DATA_DEPTH      = 32;
+
+ ram_sync_nolatch_2r2w 
+ #(BRAM_ADDR_WIDTH, BRAM_DATA_WIDTH, DATA_DEPTH) 
+ mem0(
+ .clk(clk),
+ .raddr1(raddr1),
+ .raddr2(raddr2),
+ .rdata1(rdata1),
+ .rdata2(rdata2),
+ .waddr1(waddr1),
+ .waddr2(waddr2),
+ .wdata1(wdata1),
+ .wdata2(wdata2),
+ .we1(we1),
+ .we2(we2)
+ );
+
+ ram_sync_nolatch_2r2w 
+ #(BRAM_ADDR_WIDTH, BRAM_DATA_WIDTH, DATA_DEPTH) 
+ mem1(
+ .clk(clk),
+ .raddr1(raddr3),
+ .raddr2(raddr4),
+ .rdata1(rdata3),
+ .rdata2(rdata4),
+ .waddr1(waddr1),
+ .waddr2(waddr2),
+ .wdata1(wdata1),
+ .wdata2(wdata2),
+ .we1(we1),
+ .we2(we2)
+ );
+
+ ram_sync_nolatch_2r2w 
+ #(BRAM_ADDR_WIDTH, BRAM_DATA_WIDTH, DATA_DEPTH) 
+ mem2(
+ .clk(clk),
+ .raddr1(raddr5),
+ .raddr2(raddr6),
+ .rdata1(rdata5),
+ .rdata2(rdata6),
+ .waddr1(waddr1),
+ .waddr2(waddr2),
+ .wdata1(wdata1),
+ .wdata2(wdata2),
+ .we1(we1),
+ .we2(we2)
+ );
+ 
+ endmodule // ram_sync_nolatch_6r2w
+ */
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/reorderbuf.v
+++ b/examples/SQED_ridecore/rtl/design/reorderbuf.v
@@ -1,0 +1,154 @@
+`include "constants.vh"
+`default_nettype none
+module reorderbuf
+  (
+   input wire 			  clk,
+   input wire 			  reset,
+   //Write Signal
+   input wire 			  dp1,
+   input wire [`RRF_SEL-1:0] 	  dp1_addr,
+   input wire [`INSN_LEN-1:0] 	  pc_dp1,
+   input wire 			  storebit_dp1,
+   input wire 			  dstvalid_dp1,
+   input wire [`REG_SEL-1:0] 	  dst_dp1,
+   input wire [`GSH_BHR_LEN-1:0]  bhr_dp1,
+   input wire 			  isbranch_dp1,
+   input wire 			  dp2,
+   input wire [`RRF_SEL-1:0] 	  dp2_addr,
+   input wire [`INSN_LEN-1:0] 	  pc_dp2,
+   input wire 			  storebit_dp2,
+   input wire 			  dstvalid_dp2,
+   input wire [`REG_SEL-1:0] 	  dst_dp2,
+   input wire [`GSH_BHR_LEN-1:0]  bhr_dp2,
+   input wire 			  isbranch_dp2,
+   input wire 			  exfin_alu1,
+   input wire [`RRF_SEL-1:0] 	  exfin_alu1_addr,
+   input wire 			  exfin_alu2,
+   input wire [`RRF_SEL-1:0] 	  exfin_alu2_addr,
+   input wire 			  exfin_mul,
+   input wire [`RRF_SEL-1:0] 	  exfin_mul_addr,
+   input wire 			  exfin_ldst,
+   input wire [`RRF_SEL-1:0] 	  exfin_ldst_addr,
+   input wire 			  exfin_branch,
+   input wire [`RRF_SEL-1:0] 	  exfin_branch_addr,
+   input wire 			  exfin_branch_brcond,
+   input wire [`ADDR_LEN-1:0] 	  exfin_branch_jmpaddr, 
+  
+   output reg [`RRF_SEL-1:0] 	  comptr,
+   output wire [`RRF_SEL-1:0] 	  comptr2,
+   output wire [1:0] 		  comnum,
+   output wire 			  stcommit,
+   output wire 			  arfwe1,
+   output wire 			  arfwe2,
+   output wire [`REG_SEL-1:0] 	  dstarf1,
+   output wire [`REG_SEL-1:0] 	  dstarf2,
+   output wire [`ADDR_LEN-1:0] 	  pc_combranch,
+   output wire [`GSH_BHR_LEN-1:0] bhr_combranch,
+   output wire 			  brcond_combranch,
+   output wire [`ADDR_LEN-1:0] 	  jmpaddr_combranch,
+   output wire 			  combranch,
+   input wire [`RRF_SEL-1:0] 	  dispatchptr,
+   input wire [`RRF_SEL:0] 	  rrf_freenum,
+   input wire 			  prmiss
+   );
+
+   reg [`RRF_NUM-1:0] 		  finish;
+   reg [`RRF_NUM-1:0] 		  storebit;
+   reg [`RRF_NUM-1:0] 		  dstvalid;
+   reg [`RRF_NUM-1:0] 		  brcond;
+   reg [`RRF_NUM-1:0] 		  isbranch;
+   
+   reg [`ADDR_LEN-1:0] 		  inst_pc [0:`RRF_NUM-1];
+   reg [`ADDR_LEN-1:0] 		  jmpaddr [0:`RRF_NUM-1];   
+   reg [`REG_SEL-1:0] 		  dst [0:`RRF_NUM-1];
+   reg [`GSH_BHR_LEN-1:0] 	  bhr [0:`RRF_NUM-1];
+   
+   assign comptr2 = comptr+1;
+   
+   wire 			  hidp = (comptr > dispatchptr) || (rrf_freenum == 0) ?
+				  1'b1 : 1'b0;
+   wire 			  com_en1 = ({hidp, dispatchptr} - {1'b0, comptr}) > 0 ? 1'b1 : 1'b0;
+   wire 			  com_en2 = ({hidp, dispatchptr} - {1'b0, comptr}) > 1 ? 1'b1 : 1'b0;
+   wire 			  commit1 = com_en1 & finish[comptr];
+   // EDIT: mutation: The commit condition of instruction is incomplete 
+   //wire 			  commit1 = com_en1;
+   // END EDIT
+   //   wire commit2 = commit1 & com_en2 & finish[comptr2];
+
+   wire 			  commit2 = 
+				  ~(~prmiss & commit1 & isbranch[comptr]) &
+				  ~(~prmiss & commit1 & storebit[comptr]) &
+				  commit1 & com_en2 & finish[comptr2];
+
+   assign comnum = {1'b0, commit1} + {1'b0, commit2};
+   assign stcommit = (commit1 & storebit[comptr] & ~prmiss) |
+		     (commit2 & storebit[comptr2] & ~prmiss);
+   assign arfwe1 = ~prmiss & commit1 & dstvalid[comptr];
+   assign arfwe2 = ~prmiss & commit2 & dstvalid[comptr2];
+   assign dstarf1 = dst[comptr];
+   assign dstarf2 = dst[comptr2];
+   assign combranch = (~prmiss & commit1 & isbranch[comptr]) |
+		      (~prmiss & commit2 & isbranch[comptr2]);
+   assign pc_combranch = (~prmiss & commit1 & isbranch[comptr]) ? 
+			 inst_pc[comptr] : inst_pc[comptr2];
+   assign bhr_combranch = (~prmiss & commit1 & isbranch[comptr]) ?
+			  bhr[comptr] : bhr[comptr2];
+   assign brcond_combranch = (~prmiss & commit1 & isbranch[comptr]) ?
+			     brcond[comptr] : brcond[comptr2];
+   assign jmpaddr_combranch = (~prmiss & commit1 & isbranch[comptr]) ?
+			      jmpaddr[comptr] : jmpaddr[comptr2];
+   
+
+   always @ (posedge clk) begin
+      if (reset) begin
+	 comptr <= 0;
+      end else if (~prmiss) begin
+	 comptr <= comptr + commit1 + commit2;
+      end
+   end
+   
+   always @ (posedge clk) begin
+      if (reset) begin
+	 finish <= 0;
+	 brcond <= 0;
+      end else begin
+	 if (dp1)
+	   finish[dp1_addr] <= 1'b0;
+	 if (dp2)
+	   finish[dp2_addr] <= 1'b0;
+	 if (exfin_alu1)
+	   finish[exfin_alu1_addr] <= 1'b1;
+	 if (exfin_alu2)
+	   finish[exfin_alu2_addr] <= 1'b1;
+	 if (exfin_mul)
+	   finish[exfin_mul_addr] <= 1'b1;
+	 if (exfin_ldst)
+	   finish[exfin_ldst_addr] <= 1'b1;
+	 if (exfin_branch) begin
+	    finish[exfin_branch_addr] <= 1'b1;
+	    brcond[exfin_branch_addr] <= exfin_branch_brcond;
+	    jmpaddr[exfin_branch_addr] <= exfin_branch_jmpaddr;
+	 end
+      end
+   end // always @ (posedge clk)
+
+   always @ (posedge clk) begin
+      if (dp1) begin
+	 isbranch[dp1_addr] <= isbranch_dp1;
+	 storebit[dp1_addr] <= storebit_dp1;
+	 dstvalid[dp1_addr] <= dstvalid_dp1;
+	 dst[dp1_addr] <= dst_dp1;
+	 bhr[dp1_addr] <= bhr_dp1;
+	 inst_pc[dp1_addr] <= pc_dp1;
+      end
+      if (dp2) begin
+	 isbranch[dp2_addr] <= isbranch_dp2;
+	 storebit[dp2_addr] <= storebit_dp2;
+	 dstvalid[dp2_addr] <= dstvalid_dp2;
+	 dst[dp2_addr] <= dst_dp2;
+	 bhr[dp2_addr] <= bhr_dp2;
+	 inst_pc[dp2_addr] <= pc_dp2;
+      end
+   end
+endmodule // reorderbuf
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/rrf.v
+++ b/examples/SQED_ridecore/rtl/design/rrf.v
@@ -1,0 +1,104 @@
+`include "constants.vh"
+
+/*
+ clear valid when dpen
+ set valid when wrrfen
+ */
+`default_nettype none
+module rrf(
+	   input wire 		       clk,
+	   input wire 		       reset,
+	   input wire [`RRF_SEL-1:0]   rs1_1tag,
+	   input wire [`RRF_SEL-1:0]   rs2_1tag,
+	   input wire [`RRF_SEL-1:0]   rs1_2tag,
+	   input wire [`RRF_SEL-1:0]   rs2_2tag,
+	   input wire [`RRF_SEL-1:0]   com1tag,
+	   input wire [`RRF_SEL-1:0]   com2tag,
+	   output wire 		       rs1_1valid,
+	   output wire 		       rs2_1valid,
+	   output wire 		       rs1_2valid,
+	   output wire 		       rs2_2valid,
+	   output wire [`DATA_LEN-1:0] rs1_1data,
+	   output wire [`DATA_LEN-1:0] rs2_1data,
+	   output wire [`DATA_LEN-1:0] rs1_2data,
+	   output wire [`DATA_LEN-1:0] rs2_2data,
+	   output wire [`DATA_LEN-1:0] com1data,
+	   output wire [`DATA_LEN-1:0] com2data,
+	   input wire [`RRF_SEL-1:0]   wrrfaddr1,
+	   input wire [`RRF_SEL-1:0]   wrrfaddr2,
+	   input wire [`RRF_SEL-1:0]   wrrfaddr3,
+	   input wire [`RRF_SEL-1:0]   wrrfaddr4,
+	   input wire [`RRF_SEL-1:0]   wrrfaddr5,
+	   input wire [`DATA_LEN-1:0]  wrrfdata1,
+	   input wire [`DATA_LEN-1:0]  wrrfdata2,
+	   input wire [`DATA_LEN-1:0]  wrrfdata3,
+	   input wire [`DATA_LEN-1:0]  wrrfdata4,
+	   input wire [`DATA_LEN-1:0]  wrrfdata5,
+	   input wire 		       wrrfen1,
+	   input wire 		       wrrfen2,
+	   input wire 		       wrrfen3,
+	   input wire 		       wrrfen4,
+	   input wire 		       wrrfen5,
+	   input wire [`RRF_SEL-1:0]   dpaddr1,
+	   input wire [`RRF_SEL-1:0]   dpaddr2,
+	   input wire 		       dpen1,
+	   input wire 		       dpen2
+	   );
+
+   reg [`RRF_NUM-1:0] 		       valid;
+   reg [`DATA_LEN-1:0] 		       datarr [0:`RRF_NUM-1];
+
+   assign rs1_1data = datarr[rs1_1tag];
+   assign rs2_1data = datarr[rs2_1tag];
+   assign rs1_2data = datarr[rs1_2tag];
+   assign rs2_2data = datarr[rs2_2tag];
+   assign com1data = datarr[com1tag];
+   assign com2data = datarr[com2tag];
+
+   assign rs1_1valid = valid[rs1_1tag];
+   assign rs2_1valid = valid[rs2_1tag];
+   assign rs1_2valid = valid[rs1_2tag];
+   assign rs2_2valid = valid[rs2_2tag];
+
+   wire [`RRF_NUM-1:0] 		       or_valid = 
+				       (~wrrfen1 ? `RRF_NUM'b0 : 
+					(`RRF_NUM'b1 << wrrfaddr1)) |
+				       (~wrrfen2 ? `RRF_NUM'b0 : 
+					(`RRF_NUM'b1 << wrrfaddr2)) |
+ 				       (~wrrfen3 ? `RRF_NUM'b0 : 
+					(`RRF_NUM'b1 << wrrfaddr3)) |
+				       (~wrrfen4 ? `RRF_NUM'b0 : 
+					(`RRF_NUM'b1 << wrrfaddr4)) |
+				       (~wrrfen5 ? `RRF_NUM'b0 : 
+					(`RRF_NUM'b1 << wrrfaddr5));
+   
+   wire [`RRF_NUM-1:0] 		       and_valid = 
+				       (~dpen1 ? ~(`RRF_NUM'b0) : 
+					~(`RRF_NUM'b1 << dpaddr1)) & 
+				       (~dpen2 ? ~(`RRF_NUM'b0) : 
+					~(`RRF_NUM'b1 << dpaddr2));
+
+   always @ (posedge clk) begin
+      if (reset) begin
+	 valid <= 0;
+      end else begin
+	 valid <= (valid | or_valid) & and_valid;
+      end
+   end
+
+   always @ (posedge clk) begin
+      if (~reset) begin
+	 if (wrrfen1)
+	   datarr[wrrfaddr1] <= wrrfdata1;
+	 if (wrrfen2)
+	   datarr[wrrfaddr2] <= wrrfdata2;
+	 if (wrrfen3)
+	   datarr[wrrfaddr3] <= wrrfdata3;
+	 if (wrrfen4)
+	   datarr[wrrfaddr4] <= wrrfdata4;
+	 if (wrrfen5)
+	   datarr[wrrfaddr5] <= wrrfdata5;
+      end
+   end
+endmodule // rrf
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/rrf_freelistmanager.v
+++ b/examples/SQED_ridecore/rtl/design/rrf_freelistmanager.v
@@ -1,0 +1,52 @@
+`include "constants.vh"
+`default_nettype none
+module rrf_freelistmanager
+  (
+   input wire 		      clk,
+   input wire 		      reset,
+   input wire 		      invalid1,
+   input wire 		      invalid2,
+   input wire [1:0] 	      comnum,
+   input wire 		      prmiss,
+   input wire [`RRF_SEL-1:0]  rrftagfix,
+   output wire [`RRF_SEL-1:0] rename_dst1,
+   output wire [`RRF_SEL-1:0] rename_dst2,
+   output wire 		      allocatable,
+   input wire 		      stall_DP, //= ~allocatable && ~prmiss
+   output reg [`RRF_SEL:0]    freenum,
+   output reg [`RRF_SEL-1:0]  rrfptr,
+   input wire [`RRF_SEL-1:0]  comptr,
+   output reg 		      nextrrfcyc
+   );
+   
+   wire [1:0] 		      reqnum = {1'b0, ~invalid1} + {1'b0, ~invalid2};
+   wire 		      hi = (comptr > rrftagfix) ? 1'b1 : 1'b0;
+   wire [`RRF_SEL-1:0] 	      rrfptr_next = rrfptr + reqnum;
+   
+   assign allocatable = (freenum + comnum) < reqnum ? 1'b0 : 1'b1;
+   assign rename_dst1 = rrfptr;
+   assign rename_dst2 = rrfptr + (~invalid1 ? 1 : 0);
+   
+   always @ (posedge clk) begin
+      if (reset) begin
+	 freenum <= `RRF_NUM;
+	 rrfptr <= 0;
+	 nextrrfcyc <= 0;
+      end else if (prmiss) begin
+	 rrfptr <= rrftagfix; //== prmiss_rrftag+1
+	 freenum <= `RRF_NUM - ({hi, rrftagfix} - {1'b0, comptr});
+	 nextrrfcyc <= 0;
+      end else if (stall_DP) begin
+	 rrfptr <= rrfptr;
+	 freenum <= freenum + comnum;
+	 nextrrfcyc <= 0;
+      end else begin
+	 rrfptr <= rrfptr_next;
+	 freenum <= freenum + comnum - reqnum;
+	 nextrrfcyc <= (rrfptr > rrfptr_next) ? 1'b1 : 1'b0;
+      end
+   end
+endmodule // rrf_freelistmanager
+
+
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/rs_alu.v
+++ b/examples/SQED_ridecore/rtl/design/rs_alu.v
@@ -1,0 +1,885 @@
+`include "constants.vh"
+`include "alu_ops.vh"
+`include "rv32_opcodes.vh"
+`default_nettype none
+module rs_alu_ent
+  (
+   //Memory
+   input wire 			     clk,
+   input wire 			     reset,
+   input wire 			     busy,
+   input wire [`ADDR_LEN-1:0] 	     wpc,
+   input wire [`DATA_LEN-1:0] 	     wsrc1,
+   input wire [`DATA_LEN-1:0] 	     wsrc2,
+   input wire 			     wvalid1,
+   input wire 			     wvalid2,
+   input wire [`DATA_LEN-1:0] 	     wimm,
+   input wire [`RRF_SEL-1:0] 	     wrrftag,
+   input wire 			     wdstval,
+   input wire [`SRC_A_SEL_WIDTH-1:0] wsrc_a,
+   input wire [`SRC_B_SEL_WIDTH-1:0] wsrc_b,
+   input wire [`ALU_OP_WIDTH-1:0]    walu_op,
+   input wire [`SPECTAG_LEN-1:0]     wspectag,
+   input wire 			     we,
+   output wire [`DATA_LEN-1:0] 	     ex_src1,
+   output wire [`DATA_LEN-1:0] 	     ex_src2,
+   output wire 			     ready,
+   output reg [`ADDR_LEN-1:0] 	     pc,
+   output reg [`DATA_LEN-1:0] 	     imm,
+   output reg [`RRF_SEL-1:0] 	     rrftag,
+   output reg 			     dstval,
+   output reg [`SRC_A_SEL_WIDTH-1:0] src_a,
+   output reg [`SRC_B_SEL_WIDTH-1:0] src_b,
+   output reg [`ALU_OP_WIDTH-1:0]    alu_op,
+   output reg [`SPECTAG_LEN-1:0]     spectag,
+   //EXRSLT
+   input wire [`DATA_LEN-1:0] 	     exrslt1,
+   input wire [`RRF_SEL-1:0] 	     exdst1,
+   input wire 			     kill_spec1,
+   input wire [`DATA_LEN-1:0] 	     exrslt2,
+   input wire [`RRF_SEL-1:0] 	     exdst2,
+   input wire 			     kill_spec2,
+   input wire [`DATA_LEN-1:0] 	     exrslt3,
+   input wire [`RRF_SEL-1:0] 	     exdst3,
+   input wire 			     kill_spec3,
+   input wire [`DATA_LEN-1:0] 	     exrslt4,
+   input wire [`RRF_SEL-1:0] 	     exdst4,
+   input wire 			     kill_spec4,
+   input wire [`DATA_LEN-1:0] 	     exrslt5,
+   input wire [`RRF_SEL-1:0] 	     exdst5,
+   input wire 			     kill_spec5
+   );
+
+   reg [`DATA_LEN-1:0] 		     src1;
+   reg [`DATA_LEN-1:0] 		     src2;
+   reg 				     valid1;
+   reg 				     valid2;
+
+   wire [`DATA_LEN-1:0] 	     nextsrc1;
+   wire [`DATA_LEN-1:0] 	     nextsrc2;   
+   wire 			     nextvalid1;
+   wire 			     nextvalid2;
+   
+   assign ready = busy & valid1 & valid2;
+   assign ex_src1 = ~valid1 & nextvalid1 ?
+		    nextsrc1 : src1;
+   assign ex_src2 = ~valid2 & nextvalid2 ?
+		    nextsrc2 : src2;
+   
+   always @ (posedge clk) begin
+      if (reset) begin
+	 pc <= 0;
+	 imm <= 0;
+	 rrftag <= 0;
+	 dstval <= 0;
+	 src_a <= 0;
+	 src_b <= 0;
+	 alu_op <= 0;
+	 spectag <= 0;
+
+	 src1 <= 0;
+	 src2 <= 0;
+	 valid1 <= 0;
+	 valid2 <= 0;
+      end else if (we) begin
+	 pc <= wpc;
+	 imm <= wimm;
+	 rrftag <= wrrftag;
+	 dstval <= wdstval;
+	 src_a <= wsrc_a;
+	 src_b <= wsrc_b;
+	 alu_op <= walu_op;
+	 spectag <= wspectag;
+
+	 src1 <= wsrc1;
+	 src2 <= wsrc2;
+	 valid1 <= wvalid1;
+	 valid2 <= wvalid2;
+      end else begin // if (we)
+	 src1 <= nextsrc1;
+	 src2 <= nextsrc2;
+	 valid1 <= nextvalid1;
+	 valid2 <= nextvalid2;
+      end
+   end
+   
+   src_manager srcmng1(
+		       .opr(src1),
+		       .opr_rdy(valid1),
+		       .exrslt1(exrslt1),
+		       .exdst1(exdst1),
+		       .kill_spec1(kill_spec1),
+		       .exrslt2(exrslt2),
+		       .exdst2(exdst2),
+		       .kill_spec2(kill_spec2),
+		       .exrslt3(exrslt3),
+		       .exdst3(exdst3),
+		       .kill_spec3(kill_spec3),
+		       .exrslt4(exrslt4),
+		       .exdst4(exdst4),
+		       .kill_spec4(kill_spec4),
+		       .exrslt5(exrslt5),
+		       .exdst5(exdst5),
+		       .kill_spec5(kill_spec5),
+		       .src(nextsrc1),
+		       .resolved(nextvalid1)
+		       );
+
+   src_manager srcmng2(
+		       .opr(src2),
+		       .opr_rdy(valid2),
+		       .exrslt1(exrslt1),
+		       .exdst1(exdst1),
+		       .kill_spec1(kill_spec1),
+		       .exrslt2(exrslt2),
+		       .exdst2(exdst2),
+		       .kill_spec2(kill_spec2),
+		       .exrslt3(exrslt3),
+		       .exdst3(exdst3),
+		       .kill_spec3(kill_spec3),
+		       .exrslt4(exrslt4),
+		       .exdst4(exdst4),
+		       .kill_spec4(kill_spec4),
+		       .exrslt5(exrslt5),
+		       .exdst5(exdst5),
+		       .kill_spec5(kill_spec5),
+		       .src(nextsrc2),
+		       .resolved(nextvalid2)
+		       );
+   
+endmodule // rs_alu
+
+
+module rs_alu
+  (
+   //System
+   input wire 				       clk,
+   input wire 				       reset,
+   output reg [`ALU_ENT_NUM-1:0] 	       busyvec,
+   input wire 				       prmiss,
+   input wire 				       prsuccess,
+   input wire [`SPECTAG_LEN-1:0] 	       prtag,
+   input wire [`SPECTAG_LEN-1:0] 	       specfixtag,
+   output wire [`ALU_ENT_NUM*(`RRF_SEL+2)-1:0] histvect,
+   input wire 				       nextrrfcyc, 
+   //WriteSignal
+   input wire 				       clearbusy, //Issue
+   input wire [`ALU_ENT_SEL-1:0] 	       issueaddr,
+   input wire 				       we1, //alloc1
+   input wire 				       we2, //alloc2
+   input wire [`ALU_ENT_SEL-1:0] 	       waddr1, //allocent1
+   input wire [`ALU_ENT_SEL-1:0] 	       waddr2, //allocent2
+   //WriteSignal1
+   input wire [`ADDR_LEN-1:0] 		       wpc_1,
+   input wire [`DATA_LEN-1:0] 		       wsrc1_1,
+   input wire [`DATA_LEN-1:0] 		       wsrc2_1,
+   input wire 				       wvalid1_1,
+   input wire 				       wvalid2_1,
+   input wire [`DATA_LEN-1:0] 		       wimm_1,
+   input wire [`RRF_SEL-1:0] 		       wrrftag_1,
+   input wire 				       wdstval_1,
+   input wire [`SRC_A_SEL_WIDTH-1:0] 	       wsrc_a_1,
+   input wire [`SRC_B_SEL_WIDTH-1:0] 	       wsrc_b_1,
+   input wire [`ALU_OP_WIDTH-1:0] 	       walu_op_1,
+   input wire [`SPECTAG_LEN-1:0] 	       wspectag_1,
+   input wire 				       wspecbit_1,
+   //WriteSignal2
+   input wire [`ADDR_LEN-1:0] 		       wpc_2,
+   input wire [`DATA_LEN-1:0] 		       wsrc1_2,
+   input wire [`DATA_LEN-1:0] 		       wsrc2_2,
+   input wire 				       wvalid1_2,
+   input wire 				       wvalid2_2,
+   input wire [`DATA_LEN-1:0] 		       wimm_2,
+   input wire [`RRF_SEL-1:0] 		       wrrftag_2,
+   input wire 				       wdstval_2,
+   input wire [`SRC_A_SEL_WIDTH-1:0] 	       wsrc_a_2,
+   input wire [`SRC_B_SEL_WIDTH-1:0] 	       wsrc_b_2,
+   input wire [`ALU_OP_WIDTH-1:0] 	       walu_op_2,
+   input wire [`SPECTAG_LEN-1:0] 	       wspectag_2,
+   input wire 				       wspecbit_2,
+
+   //ReadSignal
+   output wire [`DATA_LEN-1:0] 		       ex_src1,
+   output wire [`DATA_LEN-1:0] 		       ex_src2,
+   output wire [`ALU_ENT_NUM-1:0] 	       ready,
+   output wire [`ADDR_LEN-1:0] 		       pc,
+   output wire [`DATA_LEN-1:0] 		       imm,
+   output wire [`RRF_SEL-1:0] 		       rrftag,
+   output wire 				       dstval,
+   output wire [`SRC_A_SEL_WIDTH-1:0] 	       src_a,
+   output wire [`SRC_B_SEL_WIDTH-1:0] 	       src_b,
+   output wire [`ALU_OP_WIDTH-1:0] 	       alu_op,
+   output wire [`SPECTAG_LEN-1:0] 	       spectag,
+   output wire 				       specbit,
+  
+   //EXRSLT
+   input wire [`DATA_LEN-1:0] 		       exrslt1,
+   input wire [`RRF_SEL-1:0] 		       exdst1,
+   input wire 				       kill_spec1,
+   input wire [`DATA_LEN-1:0] 		       exrslt2,
+   input wire [`RRF_SEL-1:0] 		       exdst2,
+   input wire 				       kill_spec2,
+   input wire [`DATA_LEN-1:0] 		       exrslt3,
+   input wire [`RRF_SEL-1:0] 		       exdst3,
+   input wire 				       kill_spec3,
+   input wire [`DATA_LEN-1:0] 		       exrslt4,
+   input wire [`RRF_SEL-1:0] 		       exdst4,
+   input wire 				       kill_spec4,
+   input wire [`DATA_LEN-1:0] 		       exrslt5,
+   input wire [`RRF_SEL-1:0] 		       exdst5,
+   input wire 				       kill_spec5
+   );
+   
+   //_0
+   wire [`DATA_LEN-1:0] 	      ex_src1_0;
+   wire [`DATA_LEN-1:0] 	      ex_src2_0;
+   wire 			      ready_0;
+   wire [`ADDR_LEN-1:0] 	      pc_0;
+   wire [`DATA_LEN-1:0] 	      imm_0;
+   wire [`RRF_SEL-1:0] 		      rrftag_0;
+   wire 			      dstval_0;
+   wire [`SRC_A_SEL_WIDTH-1:0] 	      src_a_0;
+   wire [`SRC_B_SEL_WIDTH-1:0] 	      src_b_0;
+   wire [`ALU_OP_WIDTH-1:0] 	      alu_op_0;
+   wire [`SPECTAG_LEN-1:0] 	      spectag_0;
+   //_1
+   wire [`DATA_LEN-1:0] 	      ex_src1_1;
+   wire [`DATA_LEN-1:0] 	      ex_src2_1;
+   wire 			      ready_1;
+   wire [`ADDR_LEN-1:0] 	      pc_1;
+   wire [`DATA_LEN-1:0] 	      imm_1;
+   wire [`RRF_SEL-1:0] 		      rrftag_1;
+   wire 			      dstval_1;
+   wire [`SRC_A_SEL_WIDTH-1:0] 	      src_a_1;
+   wire [`SRC_B_SEL_WIDTH-1:0] 	      src_b_1;
+   wire [`ALU_OP_WIDTH-1:0] 	      alu_op_1;
+   wire [`SPECTAG_LEN-1:0] 	      spectag_1;
+   //_2
+   wire [`DATA_LEN-1:0] 	      ex_src1_2;
+   wire [`DATA_LEN-1:0] 	      ex_src2_2;
+   wire 			      ready_2;
+   wire [`ADDR_LEN-1:0] 	      pc_2;
+   wire [`DATA_LEN-1:0] 	      imm_2;
+   wire [`RRF_SEL-1:0] 		      rrftag_2;
+   wire 			      dstval_2;
+   wire [`SRC_A_SEL_WIDTH-1:0] 	      src_a_2;
+   wire [`SRC_B_SEL_WIDTH-1:0] 	      src_b_2;
+   wire [`ALU_OP_WIDTH-1:0] 	      alu_op_2;
+   wire [`SPECTAG_LEN-1:0] 	      spectag_2;
+   //_3
+   wire [`DATA_LEN-1:0] 	      ex_src1_3;
+   wire [`DATA_LEN-1:0] 	      ex_src2_3;
+   wire 			      ready_3;
+   wire [`ADDR_LEN-1:0] 	      pc_3;
+   wire [`DATA_LEN-1:0] 	      imm_3;
+   wire [`RRF_SEL-1:0] 		      rrftag_3;
+   wire 			      dstval_3;
+   wire [`SRC_A_SEL_WIDTH-1:0] 	      src_a_3;
+   wire [`SRC_B_SEL_WIDTH-1:0] 	      src_b_3;
+   wire [`ALU_OP_WIDTH-1:0] 	      alu_op_3;
+   wire [`SPECTAG_LEN-1:0] 	      spectag_3;
+   //_4
+   wire [`DATA_LEN-1:0] 	      ex_src1_4;
+   wire [`DATA_LEN-1:0] 	      ex_src2_4;
+   wire 			      ready_4;
+   wire [`ADDR_LEN-1:0] 	      pc_4;
+   wire [`DATA_LEN-1:0] 	      imm_4;
+   wire [`RRF_SEL-1:0] 		      rrftag_4;
+   wire 			      dstval_4;
+   wire [`SRC_A_SEL_WIDTH-1:0] 	      src_a_4;
+   wire [`SRC_B_SEL_WIDTH-1:0] 	      src_b_4;
+   wire [`ALU_OP_WIDTH-1:0] 	      alu_op_4;
+   wire [`SPECTAG_LEN-1:0] 	      spectag_4;
+   //_5
+   wire [`DATA_LEN-1:0] 	      ex_src1_5;
+   wire [`DATA_LEN-1:0] 	      ex_src2_5;
+   wire 			      ready_5;
+   wire [`ADDR_LEN-1:0] 	      pc_5;
+   wire [`DATA_LEN-1:0] 	      imm_5;
+   wire [`RRF_SEL-1:0] 		      rrftag_5;
+   wire 			      dstval_5;
+   wire [`SRC_A_SEL_WIDTH-1:0] 	      src_a_5;
+   wire [`SRC_B_SEL_WIDTH-1:0] 	      src_b_5;
+   wire [`ALU_OP_WIDTH-1:0] 	      alu_op_5;
+   wire [`SPECTAG_LEN-1:0] 	      spectag_5;
+   //_6
+   wire [`DATA_LEN-1:0] 	      ex_src1_6;
+   wire [`DATA_LEN-1:0] 	      ex_src2_6;
+   wire 			      ready_6;
+   wire [`ADDR_LEN-1:0] 	      pc_6;
+   wire [`DATA_LEN-1:0] 	      imm_6;
+   wire [`RRF_SEL-1:0] 		      rrftag_6;
+   wire 			      dstval_6;
+   wire [`SRC_A_SEL_WIDTH-1:0] 	      src_a_6;
+   wire [`SRC_B_SEL_WIDTH-1:0] 	      src_b_6;
+   wire [`ALU_OP_WIDTH-1:0] 	      alu_op_6;
+   wire [`SPECTAG_LEN-1:0] 	      spectag_6;
+   //_7
+   wire [`DATA_LEN-1:0] 	      ex_src1_7;
+   wire [`DATA_LEN-1:0] 	      ex_src2_7;
+   wire 			      ready_7;
+   wire [`ADDR_LEN-1:0] 	      pc_7;
+   wire [`DATA_LEN-1:0] 	      imm_7;
+   wire [`RRF_SEL-1:0] 		      rrftag_7;
+   wire 			      dstval_7;
+   wire [`SRC_A_SEL_WIDTH-1:0] 	      src_a_7;
+   wire [`SRC_B_SEL_WIDTH-1:0] 	      src_b_7;
+   wire [`ALU_OP_WIDTH-1:0] 	      alu_op_7;
+   wire [`SPECTAG_LEN-1:0] 	      spectag_7;
+
+   reg [`ALU_ENT_NUM-1:0] 	      specbitvec;
+   reg [`ALU_ENT_NUM-1:0] 	      sortbit;
+   
+   
+   wire [`ALU_ENT_NUM-1:0] 	      inv_vector =
+				      {(spectag_7 & specfixtag) == 0 ? 1'b1 : 1'b0,
+				       (spectag_6 & specfixtag) == 0 ? 1'b1 : 1'b0,
+				       (spectag_5 & specfixtag) == 0 ? 1'b1 : 1'b0,
+				       (spectag_4 & specfixtag) == 0 ? 1'b1 : 1'b0,
+				       (spectag_3 & specfixtag) == 0 ? 1'b1 : 1'b0,
+				       (spectag_2 & specfixtag) == 0 ? 1'b1 : 1'b0,
+				       (spectag_1 & specfixtag) == 0 ? 1'b1 : 1'b0,
+				       (spectag_0 & specfixtag) == 0 ? 1'b1 : 1'b0};
+
+   wire [`ALU_ENT_NUM-1:0] 	      inv_vector_spec =
+				      {(spectag_7 == prtag) ? 1'b0 : 1'b1,
+				       (spectag_6 == prtag) ? 1'b0 : 1'b1,
+				       (spectag_5 == prtag) ? 1'b0 : 1'b1,
+				       (spectag_4 == prtag) ? 1'b0 : 1'b1,
+				       (spectag_3 == prtag) ? 1'b0 : 1'b1,
+				       (spectag_2 == prtag) ? 1'b0 : 1'b1,
+				       (spectag_1 == prtag) ? 1'b0 : 1'b1,
+				       (spectag_0 == prtag) ? 1'b0 : 1'b1};
+
+   wire [`ALU_ENT_NUM-1:0] 	      specbitvec_next =
+				      (inv_vector_spec & specbitvec);
+   /* |
+    (we1 & wspecbit_1 ? (`ALU_ENT_SEL'b1 << waddr1) : 0) |
+    (we2 & wspecbit_2 ? (`ALU_ENT_SEL'b1 << waddr2) : 0);
+    */
+   assign specbit = prsuccess ? 
+		    specbitvec_next[issueaddr] : specbitvec[issueaddr];
+   
+   /*   
+    assign specbit = prsuccess ? 
+    ((inv_vector & busyvec) |
+    (we1 & wspecbit_1 ? (`ALU_ENT_SEL'b1 << waddr1) : 0) |
+    (we2 & wspecbit_2 ? (`ALU_ENT_SEL'b1 << waddr2) : 0)) : 
+    specbitvec[issueaddr];
+    */
+   
+   assign ready = {ready_7, ready_6, ready_5, ready_4,
+		   ready_3, ready_2, ready_1, ready_0};
+
+   assign histvect = {
+		      {~ready_7, sortbit[7], rrftag_7},
+		      {~ready_6, sortbit[6], rrftag_6},
+		      {~ready_5, sortbit[5], rrftag_5},
+		      {~ready_4, sortbit[4], rrftag_4},
+		      {~ready_3, sortbit[3], rrftag_3},
+		      {~ready_2, sortbit[2], rrftag_2},
+		      {~ready_1, sortbit[1], rrftag_1},
+		      {~ready_0, sortbit[0], rrftag_0}		      
+		      };
+
+   always @ (posedge clk) begin
+      if (reset) begin
+	 sortbit <= `ALU_ENT_NUM'b1;
+      end else if (nextrrfcyc) begin
+	 sortbit <= (we1 ? (`ALU_ENT_NUM'b1 << waddr1) : `ALU_ENT_NUM'b0) |
+		    (we2 ? (`ALU_ENT_NUM'b1 << waddr2) : `ALU_ENT_NUM'b0);
+      end else begin
+	 if (we1) begin
+	    sortbit[waddr1] <= 1'b1;
+	 end
+	 if (we2) begin
+	    sortbit[waddr2] <= 1'b1;
+	 end
+      end
+   end
+   
+   always @ (posedge clk) begin
+      if (reset) begin
+	 busyvec <= 0;
+	 specbitvec <= 0;
+      end else begin
+	 if (prmiss) begin
+	    busyvec <= inv_vector & busyvec;
+	    specbitvec <= 0;
+	 end else if (prsuccess) begin
+	    /*
+	     specbitvec <= (inv_vector & busyvec) |
+	     (we1 & wspecbit_1 ? (`ALU_ENT_SEL'b1 << waddr1) : 0) |
+	     (we2 & wspecbit_2 ? (`ALU_ENT_SEL'b1 << waddr2) : 0);
+	     */
+	    specbitvec <= specbitvec_next;
+	    /*
+	     if (we1) begin
+	     busyvec[waddr1] <= 1'b1;
+	    end
+	     if (we2) begin
+	     busyvec[waddr2] <= 1'b1;
+	    end
+	     */
+	    if (clearbusy) begin
+	       busyvec[issueaddr] <= 1'b0;
+	    end
+	 end else begin
+	    if (we1) begin
+	       busyvec[waddr1] <= 1'b1;
+	       specbitvec[waddr1] <= wspecbit_1;
+	    end
+	    if (we2) begin
+	       busyvec[waddr2] <= 1'b1;
+	       specbitvec[waddr2] <= wspecbit_2;
+	    end
+	    if (clearbusy) begin
+	       busyvec[issueaddr] <= 1'b0;
+	    end
+	 end
+      end
+   end
+
+   rs_alu_ent ent0(
+		   .clk(clk),
+		   .reset(reset),
+		   .busy(busyvec[0]),
+		   .wpc((we1 && (waddr1 == 0)) ? wpc_1 : wpc_2),
+		   .wsrc1((we1 && (waddr1 == 0)) ? wsrc1_1 : wsrc1_2),
+		   .wsrc2((we1 && (waddr1 == 0)) ? wsrc2_1 : wsrc2_2),
+		   .wvalid1((we1 && (waddr1 == 0)) ? wvalid1_1 : wvalid1_2),
+		   .wvalid2((we1 && (waddr1 == 0)) ? wvalid2_1 : wvalid2_2),
+		   .wimm((we1 && (waddr1 == 0)) ? wimm_1 : wimm_2),
+		   .wrrftag((we1 && (waddr1 == 0)) ? wrrftag_1 : wrrftag_2),
+		   .wdstval((we1 && (waddr1 == 0)) ? wdstval_1 : wdstval_2),
+		   .wsrc_a((we1 && (waddr1 == 0)) ? wsrc_a_1 : wsrc_a_2),
+		   .wsrc_b((we1 && (waddr1 == 0)) ? wsrc_b_1 : wsrc_b_2),
+		   .walu_op((we1 && (waddr1 == 0)) ? walu_op_1 : walu_op_2),
+		   .wspectag((we1 && (waddr1 == 0)) ? wspectag_1 : wspectag_2),
+		   .we((we1 && (waddr1 == 0)) || (we2 && (waddr2 == 0))),
+		   .ex_src1(ex_src1_0),
+		   .ex_src2(ex_src2_0),
+		   .ready(ready_0),
+		   .pc(pc_0),
+		   .imm(imm_0),
+		   .rrftag(rrftag_0),
+		   .dstval(dstval_0),
+		   .src_a(src_a_0),
+		   .src_b(src_b_0),
+		   .alu_op(alu_op_0),
+		   .spectag(spectag_0),
+		   .exrslt1(exrslt1),
+		   .exdst1(exdst1),
+		   .kill_spec1(kill_spec1),
+		   .exrslt2(exrslt2),
+		   .exdst2(exdst2),
+		   .kill_spec2(kill_spec2),
+		   .exrslt3(exrslt3),
+		   .exdst3(exdst3),
+		   .kill_spec3(kill_spec3),
+		   .exrslt4(exrslt4),
+		   .exdst4(exdst4),
+		   .kill_spec4(kill_spec4),
+		   .exrslt5(exrslt5),
+		   .exdst5(exdst5),
+		   .kill_spec5(kill_spec5)
+		   );
+
+   rs_alu_ent ent1(
+		   .clk(clk),
+		   .reset(reset),		   
+		   .busy(busyvec[1]),
+		   .wpc((we1 && (waddr1 == 1)) ? wpc_1 : wpc_2),
+		   .wsrc1((we1 && (waddr1 == 1)) ? wsrc1_1 : wsrc1_2),
+		   .wsrc2((we1 && (waddr1 == 1)) ? wsrc2_1 : wsrc2_2),
+		   .wvalid1((we1 && (waddr1 == 1)) ? wvalid1_1 : wvalid1_2),
+		   .wvalid2((we1 && (waddr1 == 1)) ? wvalid2_1 : wvalid2_2),
+		   .wimm((we1 && (waddr1 == 1)) ? wimm_1 : wimm_2),
+		   .wrrftag((we1 && (waddr1 == 1)) ? wrrftag_1 : wrrftag_2),
+		   .wdstval((we1 && (waddr1 == 1)) ? wdstval_1 : wdstval_2),
+		   .wsrc_a((we1 && (waddr1 == 1)) ? wsrc_a_1 : wsrc_a_2),
+		   .wsrc_b((we1 && (waddr1 == 1)) ? wsrc_b_1 : wsrc_b_2),
+		   .walu_op((we1 && (waddr1 == 1)) ? walu_op_1 : walu_op_2),
+		   .wspectag((we1 && (waddr1 == 1)) ? wspectag_1 : wspectag_2),
+		   .we((we1 && (waddr1 == 1)) || (we2 && (waddr2 == 1))),
+		   .ex_src1(ex_src1_1),
+		   .ex_src2(ex_src2_1),
+		   .ready(ready_1),
+		   .pc(pc_1),
+		   .imm(imm_1),
+		   .rrftag(rrftag_1),
+		   .dstval(dstval_1),
+		   .src_a(src_a_1),
+		   .src_b(src_b_1),
+		   .alu_op(alu_op_1),
+		   .spectag(spectag_1),
+		   .exrslt1(exrslt1),
+		   .exdst1(exdst1),
+		   .kill_spec1(kill_spec1),
+		   .exrslt2(exrslt2),
+		   .exdst2(exdst2),
+		   .kill_spec2(kill_spec2),
+		   .exrslt3(exrslt3),
+		   .exdst3(exdst3),
+		   .kill_spec3(kill_spec3),
+		   .exrslt4(exrslt4),
+		   .exdst4(exdst4),
+		   .kill_spec4(kill_spec4),
+		   .exrslt5(exrslt5),
+		   .exdst5(exdst5),
+		   .kill_spec5(kill_spec5)
+		   );
+
+   rs_alu_ent ent2(
+		   .clk(clk),
+		   .reset(reset),		   
+		   .busy(busyvec[2]),
+		   .wpc((we1 && (waddr1 == 2)) ? wpc_1 : wpc_2),
+		   .wsrc1((we1 && (waddr1 == 2)) ? wsrc1_1 : wsrc1_2),
+		   .wsrc2((we1 && (waddr1 == 2)) ? wsrc2_1 : wsrc2_2),
+		   .wvalid1((we1 && (waddr1 == 2)) ? wvalid1_1 : wvalid1_2),
+		   .wvalid2((we1 && (waddr1 == 2)) ? wvalid2_1 : wvalid2_2),
+		   .wimm((we1 && (waddr1 == 2)) ? wimm_1 : wimm_2),
+		   .wrrftag((we1 && (waddr1 == 2)) ? wrrftag_1 : wrrftag_2),
+		   .wdstval((we1 && (waddr1 == 2)) ? wdstval_1 : wdstval_2),
+		   .wsrc_a((we1 && (waddr1 == 2)) ? wsrc_a_1 : wsrc_a_2),
+		   .wsrc_b((we1 && (waddr1 == 2)) ? wsrc_b_1 : wsrc_b_2),
+		   .walu_op((we1 && (waddr1 == 2)) ? walu_op_1 : walu_op_2),
+		   .wspectag((we1 && (waddr1 == 2)) ? wspectag_1 : wspectag_2),
+		   .we((we1 && (waddr1 == 2)) || (we2 && (waddr2 == 2))),
+		   .ex_src1(ex_src1_2),
+		   .ex_src2(ex_src2_2),
+		   .ready(ready_2),
+		   .pc(pc_2),
+		   .imm(imm_2),
+		   .rrftag(rrftag_2),
+		   .dstval(dstval_2),
+		   .src_a(src_a_2),
+		   .src_b(src_b_2),
+		   .alu_op(alu_op_2),
+		   .spectag(spectag_2),
+		   .exrslt1(exrslt1),
+		   .exdst1(exdst1),
+		   .kill_spec1(kill_spec1),
+		   .exrslt2(exrslt2),
+		   .exdst2(exdst2),
+		   .kill_spec2(kill_spec2),
+		   .exrslt3(exrslt3),
+		   .exdst3(exdst3),
+		   .kill_spec3(kill_spec3),
+		   .exrslt4(exrslt4),
+		   .exdst4(exdst4),
+		   .kill_spec4(kill_spec4),
+		   .exrslt5(exrslt5),
+		   .exdst5(exdst5),
+		   .kill_spec5(kill_spec5)
+		   );
+
+   rs_alu_ent ent3(
+		   .clk(clk),
+		   .reset(reset),		   
+		   .busy(busyvec[3]),
+		   .wpc((we1 && (waddr1 == 3)) ? wpc_1 : wpc_2),
+		   .wsrc1((we1 && (waddr1 == 3)) ? wsrc1_1 : wsrc1_2),
+		   .wsrc2((we1 && (waddr1 == 3)) ? wsrc2_1 : wsrc2_2),
+		   .wvalid1((we1 && (waddr1 == 3)) ? wvalid1_1 : wvalid1_2),
+		   .wvalid2((we1 && (waddr1 == 3)) ? wvalid2_1 : wvalid2_2),
+		   .wimm((we1 && (waddr1 == 3)) ? wimm_1 : wimm_2),
+		   .wrrftag((we1 && (waddr1 == 3)) ? wrrftag_1 : wrrftag_2),
+		   .wdstval((we1 && (waddr1 == 3)) ? wdstval_1 : wdstval_2),
+		   .wsrc_a((we1 && (waddr1 == 3)) ? wsrc_a_1 : wsrc_a_2),
+		   .wsrc_b((we1 && (waddr1 == 3)) ? wsrc_b_1 : wsrc_b_2),
+		   .walu_op((we1 && (waddr1 == 3)) ? walu_op_1 : walu_op_2),
+		   .wspectag((we1 && (waddr1 == 3)) ? wspectag_1 : wspectag_2),
+		   .we((we1 && (waddr1 == 3)) || (we2 && (waddr2 == 3))),
+		   .ex_src1(ex_src1_3),
+		   .ex_src2(ex_src2_3),
+		   .ready(ready_3),
+		   .pc(pc_3),
+		   .imm(imm_3),
+		   .rrftag(rrftag_3),
+		   .dstval(dstval_3),
+		   .src_a(src_a_3),
+		   .src_b(src_b_3),
+		   .alu_op(alu_op_3),
+		   .spectag(spectag_3),
+		   .exrslt1(exrslt1),
+		   .exdst1(exdst1),
+		   .kill_spec1(kill_spec1),
+		   .exrslt2(exrslt2),
+		   .exdst2(exdst2),
+		   .kill_spec2(kill_spec2),
+		   .exrslt3(exrslt3),
+		   .exdst3(exdst3),
+		   .kill_spec3(kill_spec3),
+		   .exrslt4(exrslt4),
+		   .exdst4(exdst4),
+		   .kill_spec4(kill_spec4),
+		   .exrslt5(exrslt5),
+		   .exdst5(exdst5),
+		   .kill_spec5(kill_spec5)
+		   );
+
+   rs_alu_ent ent4(
+		   .clk(clk),
+		   .reset(reset),		   		   
+		   .busy(busyvec[4]),
+		   .wpc((we1 && (waddr1 == 4)) ? wpc_1 : wpc_2),
+		   .wsrc1((we1 && (waddr1 == 4)) ? wsrc1_1 : wsrc1_2),
+		   .wsrc2((we1 && (waddr1 == 4)) ? wsrc2_1 : wsrc2_2),
+		   .wvalid1((we1 && (waddr1 == 4)) ? wvalid1_1 : wvalid1_2),
+		   .wvalid2((we1 && (waddr1 == 4)) ? wvalid2_1 : wvalid2_2),
+		   .wimm((we1 && (waddr1 == 4)) ? wimm_1 : wimm_2),
+		   .wrrftag((we1 && (waddr1 == 4)) ? wrrftag_1 : wrrftag_2),
+		   .wdstval((we1 && (waddr1 == 4)) ? wdstval_1 : wdstval_2),
+		   .wsrc_a((we1 && (waddr1 == 4)) ? wsrc_a_1 : wsrc_a_2),
+		   .wsrc_b((we1 && (waddr1 == 4)) ? wsrc_b_1 : wsrc_b_2),
+		   .walu_op((we1 && (waddr1 == 4)) ? walu_op_1 : walu_op_2),
+		   .wspectag((we1 && (waddr1 == 4)) ? wspectag_1 : wspectag_2),
+		   .we((we1 && (waddr1 == 4)) || (we2 && (waddr2 == 4))),
+		   .ex_src1(ex_src1_4),
+		   .ex_src2(ex_src2_4),
+		   .ready(ready_4),
+		   .pc(pc_4),
+		   .imm(imm_4),
+		   .rrftag(rrftag_4),
+		   .dstval(dstval_4),
+		   .src_a(src_a_4),
+		   .src_b(src_b_4),
+		   .alu_op(alu_op_4),
+		   .spectag(spectag_4),
+		   .exrslt1(exrslt1),
+		   .exdst1(exdst1),
+		   .kill_spec1(kill_spec1),
+		   .exrslt2(exrslt2),
+		   .exdst2(exdst2),
+		   .kill_spec2(kill_spec2),
+		   .exrslt3(exrslt3),
+		   .exdst3(exdst3),
+		   .kill_spec3(kill_spec3),
+		   .exrslt4(exrslt4),
+		   .exdst4(exdst4),
+		   .kill_spec4(kill_spec4),
+		   .exrslt5(exrslt5),
+		   .exdst5(exdst5),
+		   .kill_spec5(kill_spec5)
+		   );
+
+   rs_alu_ent ent5(
+		   .clk(clk),
+		   .reset(reset),		   
+		   .busy(busyvec[5]),
+		   .wpc((we1 && (waddr1 == 5)) ? wpc_1 : wpc_2),
+		   .wsrc1((we1 && (waddr1 == 5)) ? wsrc1_1 : wsrc1_2),
+		   .wsrc2((we1 && (waddr1 == 5)) ? wsrc2_1 : wsrc2_2),
+		   .wvalid1((we1 && (waddr1 == 5)) ? wvalid1_1 : wvalid1_2),
+		   .wvalid2((we1 && (waddr1 == 5)) ? wvalid2_1 : wvalid2_2),
+		   .wimm((we1 && (waddr1 == 5)) ? wimm_1 : wimm_2),
+		   .wrrftag((we1 && (waddr1 == 5)) ? wrrftag_1 : wrrftag_2),
+		   .wdstval((we1 && (waddr1 == 5)) ? wdstval_1 : wdstval_2),
+		   .wsrc_a((we1 && (waddr1 == 5)) ? wsrc_a_1 : wsrc_a_2),
+		   .wsrc_b((we1 && (waddr1 == 5)) ? wsrc_b_1 : wsrc_b_2),
+		   .walu_op((we1 && (waddr1 == 5)) ? walu_op_1 : walu_op_2),
+		   .wspectag((we1 && (waddr1 == 5)) ? wspectag_1 : wspectag_2),
+		   .we((we1 && (waddr1 == 5)) || (we2 && (waddr2 == 5))),
+		   .ex_src1(ex_src1_5),
+		   .ex_src2(ex_src2_5),
+		   .ready(ready_5),
+		   .pc(pc_5),
+		   .imm(imm_5),
+		   .rrftag(rrftag_5),
+		   .dstval(dstval_5),
+		   .src_a(src_a_5),
+		   .src_b(src_b_5),
+		   .alu_op(alu_op_5),
+		   .spectag(spectag_5),
+		   .exrslt1(exrslt1),
+		   .exdst1(exdst1),
+		   .kill_spec1(kill_spec1),
+		   .exrslt2(exrslt2),
+		   .exdst2(exdst2),
+		   .kill_spec2(kill_spec2),
+		   .exrslt3(exrslt3),
+		   .exdst3(exdst3),
+		   .kill_spec3(kill_spec3),
+		   .exrslt4(exrslt4),
+		   .exdst4(exdst4),
+		   .kill_spec4(kill_spec4),
+		   .exrslt5(exrslt5),
+		   .exdst5(exdst5),
+		   .kill_spec5(kill_spec5)
+		   );
+
+   rs_alu_ent ent6(
+		   .clk(clk),
+		   .reset(reset),		   
+		   .busy(busyvec[6]),
+		   .wpc((we1 && (waddr1 == 6)) ? wpc_1 : wpc_2),
+		   .wsrc1((we1 && (waddr1 == 6)) ? wsrc1_1 : wsrc1_2),
+		   .wsrc2((we1 && (waddr1 == 6)) ? wsrc2_1 : wsrc2_2),
+		   .wvalid1((we1 && (waddr1 == 6)) ? wvalid1_1 : wvalid1_2),
+		   .wvalid2((we1 && (waddr1 == 6)) ? wvalid2_1 : wvalid2_2),
+		   .wimm((we1 && (waddr1 == 6)) ? wimm_1 : wimm_2),
+		   .wrrftag((we1 && (waddr1 == 6)) ? wrrftag_1 : wrrftag_2),
+		   .wdstval((we1 && (waddr1 == 6)) ? wdstval_1 : wdstval_2),
+		   .wsrc_a((we1 && (waddr1 == 6)) ? wsrc_a_1 : wsrc_a_2),
+		   .wsrc_b((we1 && (waddr1 == 6)) ? wsrc_b_1 : wsrc_b_2),
+		   .walu_op((we1 && (waddr1 == 6)) ? walu_op_1 : walu_op_2),
+		   .wspectag((we1 && (waddr1 == 6)) ? wspectag_1 : wspectag_2),
+		   .we((we1 && (waddr1 == 6)) || (we2 && (waddr2 == 6))),
+		   .ex_src1(ex_src1_6),
+		   .ex_src2(ex_src2_6),
+		   .ready(ready_6),
+		   .pc(pc_6),
+		   .imm(imm_6),
+		   .rrftag(rrftag_6),
+		   .dstval(dstval_6),
+		   .src_a(src_a_6),
+		   .src_b(src_b_6),
+		   .alu_op(alu_op_6),
+		   .spectag(spectag_6),
+		   .exrslt1(exrslt1),
+		   .exdst1(exdst1),
+		   .kill_spec1(kill_spec1),
+		   .exrslt2(exrslt2),
+		   .exdst2(exdst2),
+		   .kill_spec2(kill_spec2),
+		   .exrslt3(exrslt3),
+		   .exdst3(exdst3),
+		   .kill_spec3(kill_spec3),
+		   .exrslt4(exrslt4),
+		   .exdst4(exdst4),
+		   .kill_spec4(kill_spec4),
+		   .exrslt5(exrslt5),
+		   .exdst5(exdst5),
+		   .kill_spec5(kill_spec5)
+		   );
+
+   rs_alu_ent ent7(
+		   .clk(clk),
+		   .reset(reset),		   
+		   .busy(busyvec[7]),
+		   .wpc((we1 && (waddr1 == 7)) ? wpc_1 : wpc_2),
+		   .wsrc1((we1 && (waddr1 == 7)) ? wsrc1_1 : wsrc1_2),
+		   .wsrc2((we1 && (waddr1 == 7)) ? wsrc2_1 : wsrc2_2),
+		   .wvalid1((we1 && (waddr1 == 7)) ? wvalid1_1 : wvalid1_2),
+		   .wvalid2((we1 && (waddr1 == 7)) ? wvalid2_1 : wvalid2_2),
+		   .wimm((we1 && (waddr1 == 7)) ? wimm_1 : wimm_2),
+		   .wrrftag((we1 && (waddr1 == 7)) ? wrrftag_1 : wrrftag_2),
+		   .wdstval((we1 && (waddr1 == 7)) ? wdstval_1 : wdstval_2),
+		   .wsrc_a((we1 && (waddr1 == 7)) ? wsrc_a_1 : wsrc_a_2),
+		   .wsrc_b((we1 && (waddr1 == 7)) ? wsrc_b_1 : wsrc_b_2),
+		   .walu_op((we1 && (waddr1 == 7)) ? walu_op_1 : walu_op_2),
+		   .wspectag((we1 && (waddr1 == 7)) ? wspectag_1 : wspectag_2),
+		   .we((we1 && (waddr1 == 7)) || (we2 && (waddr2 == 7))),
+		   .ex_src1(ex_src1_7),
+		   .ex_src2(ex_src2_7),
+		   .ready(ready_7),
+		   .pc(pc_7),
+		   .imm(imm_7),
+		   .rrftag(rrftag_7),
+		   .dstval(dstval_7),
+		   .src_a(src_a_7),
+		   .src_b(src_b_7),
+		   .alu_op(alu_op_7),
+		   .spectag(spectag_7),
+		   .exrslt1(exrslt1),
+		   .exdst1(exdst1),
+		   .kill_spec1(kill_spec1),
+		   .exrslt2(exrslt2),
+		   .exdst2(exdst2),
+		   .kill_spec2(kill_spec2),
+		   .exrslt3(exrslt3),
+		   .exdst3(exdst3),
+		   .kill_spec3(kill_spec3),
+		   .exrslt4(exrslt4),
+		   .exdst4(exdst4),
+		   .kill_spec4(kill_spec4),
+		   .exrslt5(exrslt5),
+		   .exdst5(exdst5),
+		   .kill_spec5(kill_spec5)
+		   );
+   
+   assign ex_src1 = (issueaddr == 0) ? ex_src1_0 :
+		    (issueaddr == 1) ? ex_src1_1 :
+		    (issueaddr == 2) ? ex_src1_2 :
+		    (issueaddr == 3) ? ex_src1_3 :
+		    (issueaddr == 4) ? ex_src1_4 :
+		    (issueaddr == 5) ? ex_src1_5 :
+		    (issueaddr == 6) ? ex_src1_6 : ex_src1_7;
+
+   assign ex_src2 = (issueaddr == 0) ? ex_src2_0 :
+		    (issueaddr == 1) ? ex_src2_1 :
+		    (issueaddr == 2) ? ex_src2_2 :
+		    (issueaddr == 3) ? ex_src2_3 :
+		    (issueaddr == 4) ? ex_src2_4 :
+		    (issueaddr == 5) ? ex_src2_5 :
+		    (issueaddr == 6) ? ex_src2_6 : ex_src2_7;
+
+   assign pc = (issueaddr == 0) ? pc_0 :
+	       (issueaddr == 1) ? pc_1 :
+	       (issueaddr == 2) ? pc_2 :
+	       (issueaddr == 3) ? pc_3 :
+	       (issueaddr == 4) ? pc_4 :
+	       (issueaddr == 5) ? pc_5 :
+	       (issueaddr == 6) ? pc_6 : pc_7;
+   
+   assign imm = (issueaddr == 0) ? imm_0 :
+		(issueaddr == 1) ? imm_1 :
+		(issueaddr == 2) ? imm_2 :
+		(issueaddr == 3) ? imm_3 :
+		(issueaddr == 4) ? imm_4 :
+		(issueaddr == 5) ? imm_5 :
+		(issueaddr == 6) ? imm_6 : imm_7;
+   
+   assign rrftag = (issueaddr == 0) ? rrftag_0 :
+		   (issueaddr == 1) ? rrftag_1 :
+		   (issueaddr == 2) ? rrftag_2 :
+		   (issueaddr == 3) ? rrftag_3 :
+		   (issueaddr == 4) ? rrftag_4 :
+		   (issueaddr == 5) ? rrftag_5 :
+		   (issueaddr == 6) ? rrftag_6 : rrftag_7;
+   
+   assign dstval = (issueaddr == 0) ? dstval_0 :
+		   (issueaddr == 1) ? dstval_1 :
+		   (issueaddr == 2) ? dstval_2 :
+		   (issueaddr == 3) ? dstval_3 :
+		   (issueaddr == 4) ? dstval_4 :
+		   (issueaddr == 5) ? dstval_5 :
+		   (issueaddr == 6) ? dstval_6 : dstval_7;
+   
+   assign src_a = (issueaddr == 0) ? src_a_0 :
+		  (issueaddr == 1) ? src_a_1 :
+		  (issueaddr == 2) ? src_a_2 :
+		  (issueaddr == 3) ? src_a_3 :
+		  (issueaddr == 4) ? src_a_4 :
+		  (issueaddr == 5) ? src_a_5 :
+		  (issueaddr == 6) ? src_a_6 : src_a_7;
+   
+   assign src_b = (issueaddr == 0) ? src_b_0 :
+		  (issueaddr == 1) ? src_b_1 :
+		  (issueaddr == 2) ? src_b_2 :
+		  (issueaddr == 3) ? src_b_3 :
+		  (issueaddr == 4) ? src_b_4 :
+		  (issueaddr == 5) ? src_b_5 :
+		  (issueaddr == 6) ? src_b_6 : src_b_7;
+   
+   assign alu_op = (issueaddr == 0) ? alu_op_0 :
+		   (issueaddr == 1) ? alu_op_1 :
+		   (issueaddr == 2) ? alu_op_2 :
+		   (issueaddr == 3) ? alu_op_3 :
+		   (issueaddr == 4) ? alu_op_4 :
+		   (issueaddr == 5) ? alu_op_5 :
+		   (issueaddr == 6) ? alu_op_6 : alu_op_7;
+   
+   assign spectag = (issueaddr == 0) ? spectag_0 :
+		    (issueaddr == 1) ? spectag_1 :
+		    (issueaddr == 2) ? spectag_2 :
+		    (issueaddr == 3) ? spectag_3 :
+		    (issueaddr == 4) ? spectag_4 :
+		    (issueaddr == 5) ? spectag_5 :
+		    (issueaddr == 6) ? spectag_6 : spectag_7;
+
+   
+endmodule // rs_alu
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/rs_branch.v
+++ b/examples/SQED_ridecore/rtl/design/rs_branch.v
@@ -1,0 +1,614 @@
+`include "constants.vh"
+`include "alu_ops.vh"
+`include "rv32_opcodes.vh"
+`default_nettype none
+module rs_branch_ent
+  (
+   //Memory
+   input wire 			  clk,
+   input wire 			  reset,
+   input wire 			  busy,
+   input wire [`ADDR_LEN-1:0] 	  wpc,
+   input wire [`DATA_LEN-1:0] 	  wsrc1,
+   input wire [`DATA_LEN-1:0] 	  wsrc2,
+   input wire 			  wvalid1,
+   input wire 			  wvalid2,
+   input wire [`DATA_LEN-1:0] 	  wimm,
+   input wire [`RRF_SEL-1:0] 	  wrrftag,
+   input wire 			  wdstval,
+   input wire [`ALU_OP_WIDTH-1:0] walu_op,
+   input wire [`SPECTAG_LEN-1:0]  wspectag,
+   input wire [`GSH_BHR_LEN-1:0]  wbhr,
+   input wire 			  wprcond,
+   input wire [`ADDR_LEN-1:0] 	  wpraddr,
+   input wire [6:0] 		  wopcode,
+   input wire 			  we,
+   output wire [`DATA_LEN-1:0] 	  ex_src1,
+   output wire [`DATA_LEN-1:0] 	  ex_src2,
+   output wire 			  ready,
+   output reg [`ADDR_LEN-1:0] 	  pc,
+   output reg [`DATA_LEN-1:0] 	  imm,
+   output reg [`RRF_SEL-1:0] 	  rrftag,
+   output reg 			  dstval,
+   output reg [`ALU_OP_WIDTH-1:0] alu_op,
+   output reg [`SPECTAG_LEN-1:0]  spectag,
+   output reg [`GSH_BHR_LEN-1:0]  bhr,
+   output reg 			  prcond,
+   output reg [`ADDR_LEN-1:0] 	  praddr,
+   output reg [6:0] 		  opcode,
+   //EXRSLT
+   input wire [`DATA_LEN-1:0] 	  exrslt1,
+   input wire [`RRF_SEL-1:0] 	  exdst1,
+   input wire 			  kill_spec1,
+   input wire [`DATA_LEN-1:0] 	  exrslt2,
+   input wire [`RRF_SEL-1:0] 	  exdst2,
+   input wire 			  kill_spec2,
+   input wire [`DATA_LEN-1:0] 	  exrslt3,
+   input wire [`RRF_SEL-1:0] 	  exdst3,
+   input wire 			  kill_spec3,
+   input wire [`DATA_LEN-1:0] 	  exrslt4,
+   input wire [`RRF_SEL-1:0] 	  exdst4,
+   input wire 			  kill_spec4,
+   input wire [`DATA_LEN-1:0] 	  exrslt5,
+   input wire [`RRF_SEL-1:0] 	  exdst5,
+   input wire 			  kill_spec5
+   );
+
+   reg [`DATA_LEN-1:0] 		  src1;
+   reg [`DATA_LEN-1:0] 		  src2;
+   reg 				  valid1;
+   reg 				  valid2;
+
+   wire [`DATA_LEN-1:0] 	  nextsrc1;
+   wire [`DATA_LEN-1:0] 	  nextsrc2;   
+   wire 			  nextvalid1;
+   wire 			  nextvalid2;
+   
+   assign ready = busy & valid1 & valid2;
+   assign ex_src1 = ~valid1 & nextvalid1 ?
+		    nextsrc1 : src1;
+   assign ex_src2 = ~valid2 & nextvalid2 ?
+		    nextsrc2 : src2;
+   
+   always @ (posedge clk) begin
+      if (reset) begin
+	 pc <= 0;
+	 imm <= 0;
+	 rrftag <= 0;
+	 dstval <= 0;
+	 alu_op <= 0;
+	 spectag <= 0;
+	 bhr <= 0;
+	 prcond <= 0;
+	 praddr <= 0;
+	 opcode <= 0;
+	 
+	 src1 <= 0;
+	 src2 <= 0;
+	 valid1 <= 0;
+	 valid2 <= 0;
+      end else if (we) begin
+	 pc <= wpc;
+	 imm <= wimm;
+	 rrftag <= wrrftag;
+	 dstval <= wdstval;
+	 alu_op <= walu_op;
+	 spectag <= wspectag;
+	 bhr <= wbhr;
+	 prcond <= wprcond;
+	 praddr <= wpraddr;
+	 opcode <= wopcode;
+
+	 src1 <= wsrc1;
+	 src2 <= wsrc2;
+	 valid1 <= wvalid1;
+	 valid2 <= wvalid2;
+      end else begin // if (we)
+	 src1 <= nextsrc1;
+	 src2 <= nextsrc2;
+	 valid1 <= nextvalid1;
+	 valid2 <= nextvalid2;
+      end
+   end
+   
+   src_manager srcmng1(
+		       .opr(src1),
+		       .opr_rdy(valid1),
+		       .exrslt1(exrslt1),
+		       .exdst1(exdst1),
+		       .kill_spec1(kill_spec1),
+		       .exrslt2(exrslt2),
+		       .exdst2(exdst2),
+		       .kill_spec2(kill_spec2),
+		       .exrslt3(exrslt3),
+		       .exdst3(exdst3),
+		       .kill_spec3(kill_spec3),
+		       .exrslt4(exrslt4),
+		       .exdst4(exdst4),
+		       .kill_spec4(kill_spec4),
+		       .exrslt5(exrslt5),
+		       .exdst5(exdst5),
+		       .kill_spec5(kill_spec5),
+		       .src(nextsrc1),
+		       .resolved(nextvalid1)
+		       );
+
+   src_manager srcmng2(
+		       .opr(src2),
+		       .opr_rdy(valid2),
+		       .exrslt1(exrslt1),
+		       .exdst1(exdst1),
+		       .kill_spec1(kill_spec1),
+		       .exrslt2(exrslt2),
+		       .exdst2(exdst2),
+		       .kill_spec2(kill_spec2),
+		       .exrslt3(exrslt3),
+		       .exdst3(exdst3),
+		       .kill_spec3(kill_spec3),
+		       .exrslt4(exrslt4),
+		       .exdst4(exdst4),
+		       .kill_spec4(kill_spec4),
+		       .exrslt5(exrslt5),
+		       .exdst5(exdst5),
+		       .kill_spec5(kill_spec5),
+		       .src(nextsrc2),
+		       .resolved(nextvalid2)
+		       );
+   
+endmodule // rs_branch
+
+
+
+module rs_branch
+  (
+   //System
+   input wire 			     clk,
+   input wire 			     reset,
+   output reg [`BRANCH_ENT_NUM-1:0]  busyvec,
+   input wire 			     prmiss,
+   input wire 			     prsuccess,
+   input wire [`SPECTAG_LEN-1:0]     prtag,
+   input wire [`SPECTAG_LEN-1:0]     specfixtag,
+   output wire [`BRANCH_ENT_NUM-1:0] prbusyvec_next,
+   //WriteSignal
+   input wire 			     clearbusy, //Issue 
+   input wire [`BRANCH_ENT_SEL-1:0]  issueaddr, //= raddr, clsbsyadr
+   input wire 			     we1, //alloc1
+   input wire 			     we2, //alloc2
+   input wire [`BRANCH_ENT_SEL-1:0]  waddr1, //allocent1
+   input wire [`BRANCH_ENT_SEL-1:0]  waddr2, //allocent2
+   //WriteSignal1
+   input wire [`ADDR_LEN-1:0] 	     wpc_1,
+   input wire [`DATA_LEN-1:0] 	     wsrc1_1,
+   input wire [`DATA_LEN-1:0] 	     wsrc2_1,
+   input wire 			     wvalid1_1,
+   input wire 			     wvalid2_1,
+   input wire [`DATA_LEN-1:0] 	     wimm_1,
+   input wire [`RRF_SEL-1:0] 	     wrrftag_1,
+   input wire 			     wdstval_1,
+   input wire [`ALU_OP_WIDTH-1:0]    walu_op_1,
+   input wire [`SPECTAG_LEN-1:0]     wspectag_1,
+   input wire 			     wspecbit_1,
+   input wire [`GSH_BHR_LEN-1:0]     wbhr_1,
+   input wire 			     wprcond_1,
+   input wire [`ADDR_LEN-1:0] 	     wpraddr_1,
+   input wire [6:0] 		     wopcode_1,
+
+   //WriteSignal2
+   input wire [`ADDR_LEN-1:0] 	     wpc_2,
+   input wire [`DATA_LEN-1:0] 	     wsrc1_2,
+   input wire [`DATA_LEN-1:0] 	     wsrc2_2,
+   input wire 			     wvalid1_2,
+   input wire 			     wvalid2_2,
+   input wire [`DATA_LEN-1:0] 	     wimm_2,
+   input wire [`RRF_SEL-1:0] 	     wrrftag_2,
+   input wire 			     wdstval_2,
+   input wire [`ALU_OP_WIDTH-1:0]    walu_op_2,
+   input wire [`SPECTAG_LEN-1:0]     wspectag_2,
+   input wire 			     wspecbit_2,
+   input wire [`GSH_BHR_LEN-1:0]     wbhr_2,
+   input wire 			     wprcond_2,
+   input wire [`ADDR_LEN-1:0] 	     wpraddr_2,
+   input wire [6:0] 		     wopcode_2,
+
+   //ReadSignal
+   output wire [`DATA_LEN-1:0] 	     ex_src1,
+   output wire [`DATA_LEN-1:0] 	     ex_src2,
+   output wire [`BRANCH_ENT_NUM-1:0] ready,
+   output wire [`ADDR_LEN-1:0] 	     pc,
+   output wire [`DATA_LEN-1:0] 	     imm,
+   output wire [`RRF_SEL-1:0] 	     rrftag,
+   output wire 			     dstval,
+   output wire [`ALU_OP_WIDTH-1:0]   alu_op,
+   output wire [`SPECTAG_LEN-1:0]    spectag,
+   output wire 			     specbit,
+   output wire [`GSH_BHR_LEN-1:0]    bhr,
+   output wire 			     prcond,
+   output wire [`ADDR_LEN-1:0] 	     praddr,
+   output wire [6:0] 		     opcode,
+  
+   //EXRSLT
+   input wire [`DATA_LEN-1:0] 	     exrslt1,
+   input wire [`RRF_SEL-1:0] 	     exdst1,
+   input wire 			     kill_spec1,
+   input wire [`DATA_LEN-1:0] 	     exrslt2,
+   input wire [`RRF_SEL-1:0] 	     exdst2,
+   input wire 			     kill_spec2,
+   input wire [`DATA_LEN-1:0] 	     exrslt3,
+   input wire [`RRF_SEL-1:0] 	     exdst3,
+   input wire 			     kill_spec3,
+   input wire [`DATA_LEN-1:0] 	     exrslt4,
+   input wire [`RRF_SEL-1:0] 	     exdst4,
+   input wire 			     kill_spec4,
+   input wire [`DATA_LEN-1:0] 	     exrslt5,
+   input wire [`RRF_SEL-1:0] 	     exdst5,
+   input wire 			     kill_spec5
+   );
+
+   //_0
+   wire [`DATA_LEN-1:0] 	     ex_src1_0;
+   wire [`DATA_LEN-1:0] 	     ex_src2_0;
+   wire 			     ready_0;
+   wire [`ADDR_LEN-1:0] 	     pc_0;
+   wire [`DATA_LEN-1:0] 	     imm_0;
+   wire [`RRF_SEL-1:0] 		     rrftag_0;
+   wire 			     dstval_0;
+   wire [`ALU_OP_WIDTH-1:0] 	     alu_op_0;
+   wire [`SPECTAG_LEN-1:0] 	     spectag_0;
+   wire [`GSH_BHR_LEN-1:0] 	     bhr_0;
+   wire 			     prcond_0;
+   wire [`ADDR_LEN-1:0] 	     praddr_0;
+   wire [6:0] 			     opcode_0;
+   //_1
+   wire [`DATA_LEN-1:0] 	     ex_src1_1;
+   wire [`DATA_LEN-1:0] 	     ex_src2_1;
+   wire 			     ready_1;
+   wire [`ADDR_LEN-1:0] 	     pc_1;
+   wire [`DATA_LEN-1:0] 	     imm_1;
+   wire [`RRF_SEL-1:0] 		     rrftag_1;
+   wire 			     dstval_1;
+   wire [`ALU_OP_WIDTH-1:0] 	     alu_op_1;
+   wire [`SPECTAG_LEN-1:0] 	     spectag_1;
+   wire [`GSH_BHR_LEN-1:0] 	     bhr_1;
+   wire 			     prcond_1;
+   wire [`ADDR_LEN-1:0] 	     praddr_1;
+   wire [6:0] 			     opcode_1;
+   //_2
+   wire [`DATA_LEN-1:0] 	     ex_src1_2;
+   wire [`DATA_LEN-1:0] 	     ex_src2_2;
+   wire 			     ready_2;
+   wire [`ADDR_LEN-1:0] 	     pc_2;
+   wire [`DATA_LEN-1:0] 	     imm_2;
+   wire [`RRF_SEL-1:0] 		     rrftag_2;
+   wire 			     dstval_2;
+   wire [`ALU_OP_WIDTH-1:0] 	     alu_op_2;
+   wire [`SPECTAG_LEN-1:0] 	     spectag_2;
+   wire [`GSH_BHR_LEN-1:0] 	     bhr_2;
+   wire 			     prcond_2;
+   wire [`ADDR_LEN-1:0] 	     praddr_2;
+   wire [6:0] 			     opcode_2;
+   //_3
+   wire [`DATA_LEN-1:0] 	     ex_src1_3;
+   wire [`DATA_LEN-1:0] 	     ex_src2_3;
+   wire 			     ready_3;
+   wire [`ADDR_LEN-1:0] 	     pc_3;
+   wire [`DATA_LEN-1:0] 	     imm_3;
+   wire [`RRF_SEL-1:0] 		     rrftag_3;
+   wire 			     dstval_3;
+   wire [`ALU_OP_WIDTH-1:0] 	     alu_op_3;
+   wire [`SPECTAG_LEN-1:0] 	     spectag_3;
+   wire [`GSH_BHR_LEN-1:0] 	     bhr_3;
+   wire 			     prcond_3;
+   wire [`ADDR_LEN-1:0] 	     praddr_3;
+   wire [6:0] 			     opcode_3;
+   
+   reg [`BRANCH_ENT_NUM-1:0] 	     specbitvec;
+
+   wire [`BRANCH_ENT_NUM-1:0] 	     inv_vector =
+				     {(spectag_3 & specfixtag) == 0 ? 1'b1 : 1'b0,
+				      (spectag_2 & specfixtag) == 0 ? 1'b1 : 1'b0,
+				      (spectag_1 & specfixtag) == 0 ? 1'b1 : 1'b0,
+				      (spectag_0 & specfixtag) == 0 ? 1'b1 : 1'b0};
+
+   wire [`BRANCH_ENT_NUM-1:0] 	     inv_vector_spec =
+				     {(spectag_3 == prtag) ? 1'b0 : 1'b1,
+				      (spectag_2 == prtag) ? 1'b0 : 1'b1,
+				      (spectag_1 == prtag) ? 1'b0 : 1'b1,
+				      (spectag_0 == prtag) ? 1'b0 : 1'b1};
+
+   wire [`BRANCH_ENT_NUM-1:0] 	     specbitvec_next =
+				     (inv_vector_spec & specbitvec);
+   /* |
+    (we1 & wspecbit_1 ? (`BRANCH_ENT_SEL'b1 << waddr1) : 0) |
+    (we2 & wspecbit_2 ? (`BRANCH_ENT_SEL'b1 << waddr2) : 0);
+    */
+   assign specbit = prsuccess ? 
+		    specbitvec_next[issueaddr] : specbitvec[issueaddr];
+   
+   assign ready = {ready_3, ready_2, ready_1, ready_0};
+   assign prbusyvec_next = inv_vector & busyvec;
+   
+   always @ (posedge clk) begin
+      if (reset) begin
+	 busyvec <= 0;
+	 specbitvec <= 0;
+      end else begin
+	 if (prmiss) begin
+	    busyvec <= prbusyvec_next;
+	    specbitvec <= 0;
+	 end else if (prsuccess) begin
+	    specbitvec <= specbitvec_next;
+	    /*
+	     if (we1) begin
+	     busyvec[waddr1] <= 1'b1;
+	    end
+	     if (we2) begin
+	     busyvec[waddr2] <= 1'b1;
+	    end
+	     */
+	    if (clearbusy) begin
+	       busyvec[issueaddr] <= 1'b0;
+	    end
+	 end else begin
+	    if (we1) begin
+	       busyvec[waddr1] <= 1'b1;
+	       specbitvec[waddr1] <= wspecbit_1;
+	    end
+	    if (we2) begin
+	       busyvec[waddr2] <= 1'b1;
+	       specbitvec[waddr2] <= wspecbit_2;
+	    end
+	    if (clearbusy) begin
+	       busyvec[issueaddr] <= 1'b0;
+	    end
+	 end
+      end
+   end
+
+   rs_branch_ent ent0(
+		      .clk(clk),
+		      .reset(reset),		      
+		      .busy(busyvec[0]),
+		      .wpc((we1 && (waddr1 == 0)) ? wpc_1 : wpc_2),
+		      .wsrc1((we1 && (waddr1 == 0)) ? wsrc1_1 : wsrc1_2),
+		      .wsrc2((we1 && (waddr1 == 0)) ? wsrc2_1 : wsrc2_2),
+		      .wvalid1((we1 && (waddr1 == 0)) ? wvalid1_1 : wvalid1_2),
+		      .wvalid2((we1 && (waddr1 == 0)) ? wvalid2_1 : wvalid2_2),
+		      .wimm((we1 && (waddr1 == 0)) ? wimm_1 : wimm_2),
+		      .wrrftag((we1 && (waddr1 == 0)) ? wrrftag_1 : wrrftag_2),
+		      .wdstval((we1 && (waddr1 == 0)) ? wdstval_1 : wdstval_2),
+		      .walu_op((we1 && (waddr1 == 0)) ? walu_op_1 : walu_op_2),
+		      .wspectag((we1 && (waddr1 == 0)) ? wspectag_1 : wspectag_2),
+		      .wbhr((we1 && (waddr1 == 0)) ? wbhr_1 : wbhr_2),
+		      .wpraddr((we1 && (waddr1 == 0)) ? wpraddr_1 : wpraddr_2),
+		      .wprcond((we1 && (waddr1 == 0)) ? wprcond_1 : wprcond_2),
+		      .wopcode((we1 && (waddr1 == 0)) ? wopcode_1 : wopcode_2),
+		      .we((we1 && (waddr1 == 0)) || (we2 && (waddr2 == 0))),
+		      .ex_src1(ex_src1_0),
+		      .ex_src2(ex_src2_0),
+		      .ready(ready_0),
+		      .pc(pc_0),
+		      .imm(imm_0),
+		      .rrftag(rrftag_0),
+		      .dstval(dstval_0),
+		      .alu_op(alu_op_0),
+		      .spectag(spectag_0),
+		      .bhr(bhr_0),
+		      .prcond(prcond_0),
+		      .praddr(praddr_0),
+		      .opcode(opcode_0),
+		      .exrslt1(exrslt1),
+		      .exdst1(exdst1),
+		      .kill_spec1(kill_spec1),
+		      .exrslt2(exrslt2),
+		      .exdst2(exdst2),
+		      .kill_spec2(kill_spec2),
+		      .exrslt3(exrslt3),
+		      .exdst3(exdst3),
+		      .kill_spec3(kill_spec3),
+		      .exrslt4(exrslt4),
+		      .exdst4(exdst4),
+		      .kill_spec4(kill_spec4),
+		      .exrslt5(exrslt5),
+		      .exdst5(exdst5),
+		      .kill_spec5(kill_spec5)
+		      );
+
+   rs_branch_ent ent1(
+		      .clk(clk),
+		      .reset(reset),		      		      
+		      .busy(busyvec[1]),
+		      .wpc((we1 && (waddr1 == 1)) ? wpc_1 : wpc_2),
+		      .wsrc1((we1 && (waddr1 == 1)) ? wsrc1_1 : wsrc1_2),
+		      .wsrc2((we1 && (waddr1 == 1)) ? wsrc2_1 : wsrc2_2),
+		      .wvalid1((we1 && (waddr1 == 1)) ? wvalid1_1 : wvalid1_2),
+		      .wvalid2((we1 && (waddr1 == 1)) ? wvalid2_1 : wvalid2_2),
+		      .wimm((we1 && (waddr1 == 1)) ? wimm_1 : wimm_2),
+		      .wrrftag((we1 && (waddr1 == 1)) ? wrrftag_1 : wrrftag_2),
+		      .wdstval((we1 && (waddr1 == 1)) ? wdstval_1 : wdstval_2),
+		      .walu_op((we1 && (waddr1 == 1)) ? walu_op_1 : walu_op_2),
+		      .wspectag((we1 && (waddr1 == 1)) ? wspectag_1 : wspectag_2),
+		      .wbhr((we1 && (waddr1 == 1)) ? wbhr_1 : wbhr_2),
+		      .wpraddr((we1 && (waddr1 == 1)) ? wpraddr_1 : wpraddr_2),
+		      .wprcond((we1 && (waddr1 == 1)) ? wprcond_1 : wprcond_2),
+		      .wopcode((we1 && (waddr1 == 1)) ? wopcode_1 : wopcode_2),
+		      .we((we1 && (waddr1 == 1)) || (we2 && (waddr2 == 1))),
+		      .ex_src1(ex_src1_1),
+		      .ex_src2(ex_src2_1),
+		      .ready(ready_1),
+		      .pc(pc_1),
+		      .imm(imm_1),
+		      .rrftag(rrftag_1),
+		      .dstval(dstval_1),
+		      .alu_op(alu_op_1),
+		      .spectag(spectag_1),
+		      .bhr(bhr_1),
+		      .prcond(prcond_1),
+		      .praddr(praddr_1),
+		      .opcode(opcode_1),
+		      .exrslt1(exrslt1),
+		      .exdst1(exdst1),
+		      .kill_spec1(kill_spec1),
+		      .exrslt2(exrslt2),
+		      .exdst2(exdst2),
+		      .kill_spec2(kill_spec2),
+		      .exrslt3(exrslt3),
+		      .exdst3(exdst3),
+		      .kill_spec3(kill_spec3),
+		      .exrslt4(exrslt4),
+		      .exdst4(exdst4),
+		      .kill_spec4(kill_spec4),
+		      .exrslt5(exrslt5),
+		      .exdst5(exdst5),
+		      .kill_spec5(kill_spec5)
+		      );
+
+   rs_branch_ent ent2(
+		      .clk(clk),
+		      .reset(reset),		      		      
+		      .busy(busyvec[2]),
+		      .wpc((we1 && (waddr1 == 2)) ? wpc_1 : wpc_2),
+		      .wsrc1((we1 && (waddr1 == 2)) ? wsrc1_1 : wsrc1_2),
+		      .wsrc2((we1 && (waddr1 == 2)) ? wsrc2_1 : wsrc2_2),
+		      .wvalid1((we1 && (waddr1 == 2)) ? wvalid1_1 : wvalid1_2),
+		      .wvalid2((we1 && (waddr1 == 2)) ? wvalid2_1 : wvalid2_2),
+		      .wimm((we1 && (waddr1 == 2)) ? wimm_1 : wimm_2),
+		      .wrrftag((we1 && (waddr1 == 2)) ? wrrftag_1 : wrrftag_2),
+		      .wdstval((we1 && (waddr1 == 2)) ? wdstval_1 : wdstval_2),
+		      .walu_op((we1 && (waddr1 == 2)) ? walu_op_1 : walu_op_2),
+		      .wspectag((we1 && (waddr1 == 2)) ? wspectag_1 : wspectag_2),
+		      .wbhr((we1 && (waddr1 == 2)) ? wbhr_1 : wbhr_2),
+		      .wpraddr((we1 && (waddr1 == 2)) ? wpraddr_1 : wpraddr_2),
+		      .wprcond((we1 && (waddr1 == 2)) ? wprcond_1 : wprcond_2),
+		      .wopcode((we1 && (waddr1 == 2)) ? wopcode_1 : wopcode_2),
+		      .we((we1 && (waddr1 == 2)) || (we2 && (waddr2 == 2))),
+		      .ex_src1(ex_src1_2),
+		      .ex_src2(ex_src2_2),
+		      .ready(ready_2),
+		      .pc(pc_2),
+		      .imm(imm_2),
+		      .rrftag(rrftag_2),
+		      .dstval(dstval_2),
+		      .alu_op(alu_op_2),
+		      .spectag(spectag_2),
+		      .bhr(bhr_2),
+		      .prcond(prcond_2),
+		      .praddr(praddr_2),
+		      .opcode(opcode_2),
+		      .exrslt1(exrslt1),
+		      .exdst1(exdst1),
+		      .kill_spec1(kill_spec1),
+		      .exrslt2(exrslt2),
+		      .exdst2(exdst2),
+		      .kill_spec2(kill_spec2),
+		      .exrslt3(exrslt3),
+		      .exdst3(exdst3),
+		      .kill_spec3(kill_spec3),
+		      .exrslt4(exrslt4),
+		      .exdst4(exdst4),
+		      .kill_spec4(kill_spec4),
+		      .exrslt5(exrslt5),
+		      .exdst5(exdst5),
+		      .kill_spec5(kill_spec5)
+		      );
+
+   rs_branch_ent ent3(
+		      .clk(clk),
+		      .reset(reset),		      		      
+		      .busy(busyvec[3]),
+		      .wpc((we1 && (waddr1 == 3)) ? wpc_1 : wpc_2),
+		      .wsrc1((we1 && (waddr1 == 3)) ? wsrc1_1 : wsrc1_2),
+		      .wsrc2((we1 && (waddr1 == 3)) ? wsrc2_1 : wsrc2_2),
+		      .wvalid1((we1 && (waddr1 == 3)) ? wvalid1_1 : wvalid1_2),
+		      .wvalid2((we1 && (waddr1 == 3)) ? wvalid2_1 : wvalid2_2),
+		      .wimm((we1 && (waddr1 == 3)) ? wimm_1 : wimm_2),
+		      .wrrftag((we1 && (waddr1 == 3)) ? wrrftag_1 : wrrftag_2),
+		      .wdstval((we1 && (waddr1 == 3)) ? wdstval_1 : wdstval_2),
+		      .walu_op((we1 && (waddr1 == 3)) ? walu_op_1 : walu_op_2),
+		      .wspectag((we1 && (waddr1 == 3)) ? wspectag_1 : wspectag_2),
+		      .wbhr((we1 && (waddr1 == 3)) ? wbhr_1 : wbhr_2),
+		      .wpraddr((we1 && (waddr1 == 3)) ? wpraddr_1 : wpraddr_2),
+		      .wprcond((we1 && (waddr1 == 3)) ? wprcond_1 : wprcond_2),
+		      .wopcode((we1 && (waddr1 == 3)) ? wopcode_1 : wopcode_2),
+		      .we((we1 && (waddr1 == 3)) || (we2 && (waddr2 == 3))),
+		      .ex_src1(ex_src1_3),
+		      .ex_src2(ex_src2_3),
+		      .ready(ready_3),
+		      .pc(pc_3),
+		      .imm(imm_3),
+		      .rrftag(rrftag_3),
+		      .dstval(dstval_3),
+		      .alu_op(alu_op_3),
+		      .spectag(spectag_3),
+		      .bhr(bhr_3),
+		      .prcond(prcond_3),
+		      .praddr(praddr_3),
+		      .opcode(opcode_3),
+		      .exrslt1(exrslt1),
+		      .exdst1(exdst1),
+		      .kill_spec1(kill_spec1),
+		      .exrslt2(exrslt2),
+		      .exdst2(exdst2),
+		      .kill_spec2(kill_spec2),
+		      .exrslt3(exrslt3),
+		      .exdst3(exdst3),
+		      .kill_spec3(kill_spec3),
+		      .exrslt4(exrslt4),
+		      .exdst4(exdst4),
+		      .kill_spec4(kill_spec4),
+		      .exrslt5(exrslt5),
+		      .exdst5(exdst5),
+		      .kill_spec5(kill_spec5)
+		      );
+   
+   assign ex_src1 = (issueaddr == 0) ? ex_src1_0 :
+		    (issueaddr == 1) ? ex_src1_1 :
+		    (issueaddr == 2) ? ex_src1_2 : ex_src1_3;
+   
+   assign ex_src2 = (issueaddr == 0) ? ex_src2_0 :
+		    (issueaddr == 1) ? ex_src2_1 :
+		    (issueaddr == 2) ? ex_src2_2 : ex_src2_3;
+   
+   assign pc = (issueaddr == 0) ? pc_0 :
+	       (issueaddr == 1) ? pc_1 :
+	       (issueaddr == 2) ? pc_2 : pc_3;
+   
+   assign imm = (issueaddr == 0) ? imm_0 :
+		(issueaddr == 1) ? imm_1 :
+		(issueaddr == 2) ? imm_2 : imm_3;
+   
+   assign rrftag = (issueaddr == 0) ? rrftag_0 :
+		   (issueaddr == 1) ? rrftag_1 :
+		   (issueaddr == 2) ? rrftag_2 : rrftag_3;
+   
+   assign dstval = (issueaddr == 0) ? dstval_0 :
+		   (issueaddr == 1) ? dstval_1 :
+		   (issueaddr == 2) ? dstval_2 : dstval_3;
+
+   assign alu_op = (issueaddr == 0) ? alu_op_0 :
+		   (issueaddr == 1) ? alu_op_1 :
+		   (issueaddr == 2) ? alu_op_2 : alu_op_3;
+
+   assign spectag = (issueaddr == 0) ? spectag_0 :
+		    (issueaddr == 1) ? spectag_1 :
+		    (issueaddr == 2) ? spectag_2 : spectag_3;
+   
+   assign bhr = (issueaddr == 0) ? bhr_0 :
+		(issueaddr == 1) ? bhr_1 :
+		(issueaddr == 2) ? bhr_2 : bhr_3;
+   
+   assign prcond = (issueaddr == 0) ? prcond_0 :
+		   (issueaddr == 1) ? prcond_1 :
+		   (issueaddr == 2) ? prcond_2 : prcond_3;
+   
+   assign praddr = (issueaddr == 0) ? praddr_0 :
+		   (issueaddr == 1) ? praddr_1 :
+		   (issueaddr == 2) ? praddr_2 : praddr_3;
+   
+   assign opcode = (issueaddr == 0) ? opcode_0 :
+		   (issueaddr == 1) ? opcode_1 :
+		   (issueaddr == 2) ? opcode_2 : opcode_3;
+   
+   
+endmodule // rs_branch
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/rs_ldst.v
+++ b/examples/SQED_ridecore/rtl/design/rs_ldst.v
@@ -1,0 +1,497 @@
+`include "constants.vh"
+`default_nettype none
+module rs_ldst_ent
+  (
+   //Memory
+   input wire 			 clk,
+   input wire 			 reset,
+   input wire 			 busy,
+   input wire [`ADDR_LEN-1:0] 	 wpc,
+   input wire [`DATA_LEN-1:0] 	 wsrc1,
+   input wire [`DATA_LEN-1:0] 	 wsrc2,
+   input wire 			 wvalid1,
+   input wire 			 wvalid2,
+   input wire [`DATA_LEN-1:0] 	 wimm,
+   input wire [`RRF_SEL-1:0] 	 wrrftag,
+   input wire 			 wdstval,
+   input wire [`SPECTAG_LEN-1:0] 	 wspectag,
+   input wire 			 we,
+   output wire [`DATA_LEN-1:0] 	 ex_src1,
+   output wire [`DATA_LEN-1:0] 	 ex_src2,
+   output wire 			 ready,
+   output reg [`ADDR_LEN-1:0] 	 pc,
+   output reg [`DATA_LEN-1:0] 	 imm,
+   output reg [`RRF_SEL-1:0] 	 rrftag,
+   output reg 			 dstval,
+   output reg [`SPECTAG_LEN-1:0] spectag,
+   //EXRSLT
+   input wire [`DATA_LEN-1:0] 	 exrslt1,
+   input wire [`RRF_SEL-1:0] 	 exdst1,
+   input wire 			 kill_spec1,
+   input wire [`DATA_LEN-1:0] 	 exrslt2,
+   input wire [`RRF_SEL-1:0] 	 exdst2,
+   input wire 			 kill_spec2,
+   input wire [`DATA_LEN-1:0] 	 exrslt3,
+   input wire [`RRF_SEL-1:0] 	 exdst3,
+   input wire 			 kill_spec3,
+   input wire [`DATA_LEN-1:0] 	 exrslt4,
+   input wire [`RRF_SEL-1:0] 	 exdst4,
+   input wire 			 kill_spec4,
+   input wire [`DATA_LEN-1:0] 	 exrslt5,
+   input wire [`RRF_SEL-1:0] 	 exdst5,
+   input wire 			 kill_spec5
+   );
+
+   reg [`DATA_LEN-1:0] 		 src1;
+   reg [`DATA_LEN-1:0] 		 src2;
+   reg 				 valid1;
+   reg 				 valid2;
+
+   wire [`DATA_LEN-1:0] 	 nextsrc1;
+   wire [`DATA_LEN-1:0] 	 nextsrc2;   
+   wire 			 nextvalid1;
+   wire 			 nextvalid2;
+   
+   assign ready = busy & valid1 & valid2;
+   assign ex_src1 = ~valid1 & nextvalid1 ?
+		    nextsrc1 : src1;
+   assign ex_src2 = ~valid2 & nextvalid2 ?
+		    nextsrc2 : src2;
+   
+   always @ (posedge clk) begin
+      if (reset) begin
+	 pc <= 0;
+	 imm <= 0;
+	 rrftag <= 0;
+	 dstval <= 0;
+	 spectag <= 0;
+
+	 src1 <= 0;
+	 src2 <= 0;
+	 valid1 <= 0;
+	 valid2 <= 0;
+      end else if (we) begin
+	 pc <= wpc;
+	 imm <= wimm;
+	 rrftag <= wrrftag;
+	 dstval <= wdstval;
+	 spectag <= wspectag;
+
+	 src1 <= wsrc1;
+	 src2 <= wsrc2;
+	 valid1 <= wvalid1;
+	 valid2 <= wvalid2;
+      end else begin // if (we)
+	 src1 <= nextsrc1;
+	 src2 <= nextsrc2;
+	 valid1 <= nextvalid1;
+	 valid2 <= nextvalid2;
+      end
+   end
+   
+   src_manager srcmng1(
+		       .opr(src1),
+		       .opr_rdy(valid1),
+		       .exrslt1(exrslt1),
+		       .exdst1(exdst1),
+		       .kill_spec1(kill_spec1),
+		       .exrslt2(exrslt2),
+		       .exdst2(exdst2),
+		       .kill_spec2(kill_spec2),
+		       .exrslt3(exrslt3),
+		       .exdst3(exdst3),
+		       .kill_spec3(kill_spec3),
+		       .exrslt4(exrslt4),
+		       .exdst4(exdst4),
+		       .kill_spec4(kill_spec4),
+		       .exrslt5(exrslt5),
+		       .exdst5(exdst5),
+		       .kill_spec5(kill_spec5),
+		       .src(nextsrc1),
+		       .resolved(nextvalid1)
+		       );
+
+   src_manager srcmng2(
+		       .opr(src2),
+		       .opr_rdy(valid2),
+		       .exrslt1(exrslt1),
+		       .exdst1(exdst1),
+		       .kill_spec1(kill_spec1),
+		       .exrslt2(exrslt2),
+		       .exdst2(exdst2),
+		       .kill_spec2(kill_spec2),
+		       .exrslt3(exrslt3),
+		       .exdst3(exdst3),
+		       .kill_spec3(kill_spec3),
+		       .exrslt4(exrslt4),
+		       .exdst4(exdst4),
+		       .kill_spec4(kill_spec4),
+		       .exrslt5(exrslt5),
+		       .exdst5(exdst5),
+		       .kill_spec5(kill_spec5),
+		       .src(nextsrc2),
+		       .resolved(nextvalid2)
+		       );
+   
+endmodule // rs_ldst
+
+
+module rs_ldst
+  (
+   //System
+   input wire 			   clk,
+   input wire 			   reset,
+   output reg [`LDST_ENT_NUM-1:0]  busyvec,
+   input wire 			   prmiss,
+   input wire 			   prsuccess,
+   input wire [`SPECTAG_LEN-1:0] 	   prtag,
+   input wire [`SPECTAG_LEN-1:0] 	   specfixtag,
+   output wire [`LDST_ENT_NUM-1:0] prbusyvec_next,
+   //WriteSignal
+   input wire 			   clearbusy, //Issue 
+   input wire [`LDST_ENT_SEL-1:0] 	   issueaddr, //= raddr, clsbsyadr
+   input wire 			   we1, //alloc1
+   input wire 			   we2, //alloc2
+   input wire [`LDST_ENT_SEL-1:0] 	   waddr1, //allocent1
+   input wire [`LDST_ENT_SEL-1:0] 	   waddr2, //allocent2
+   //WriteSignal1
+   input wire [`ADDR_LEN-1:0] 	   wpc_1,
+   input wire [`DATA_LEN-1:0] 	   wsrc1_1,
+   input wire [`DATA_LEN-1:0] 	   wsrc2_1,
+   input wire 			   wvalid1_1,
+   input wire 			   wvalid2_1,
+   input wire [`DATA_LEN-1:0] 	   wimm_1,
+   input wire [`RRF_SEL-1:0] 	   wrrftag_1,
+   input wire 			   wdstval_1,
+   input wire [`SPECTAG_LEN-1:0] 	   wspectag_1,
+   input wire 			   wspecbit_1,
+   //WriteSignal2
+   input wire [`ADDR_LEN-1:0] 	   wpc_2,
+   input wire [`DATA_LEN-1:0] 	   wsrc1_2,
+   input wire [`DATA_LEN-1:0] 	   wsrc2_2,
+   input wire 			   wvalid1_2,
+   input wire 			   wvalid2_2,
+   input wire [`DATA_LEN-1:0] 	   wimm_2,
+   input wire [`RRF_SEL-1:0] 	   wrrftag_2,
+   input wire 			   wdstval_2,
+   input wire [`SPECTAG_LEN-1:0] 	   wspectag_2,
+   input wire 			   wspecbit_2,
+
+   //ReadSignal
+   output wire [`DATA_LEN-1:0] 	   ex_src1,
+   output wire [`DATA_LEN-1:0] 	   ex_src2,
+   output wire [`LDST_ENT_NUM-1:0] ready,
+   output wire [`ADDR_LEN-1:0] 	   pc,
+   output wire [`DATA_LEN-1:0] 	   imm,
+   output wire [`RRF_SEL-1:0] 	   rrftag,
+   output wire 			   dstval,
+   output wire [`SPECTAG_LEN-1:0]  spectag,
+   output wire 			   specbit,
+  
+   //EXRSLT
+   input wire [`DATA_LEN-1:0] 	   exrslt1,
+   input wire [`RRF_SEL-1:0] 	   exdst1,
+   input wire 			   kill_spec1,
+   input wire [`DATA_LEN-1:0] 	   exrslt2,
+   input wire [`RRF_SEL-1:0] 	   exdst2,
+   input wire 			   kill_spec2,
+   input wire [`DATA_LEN-1:0] 	   exrslt3,
+   input wire [`RRF_SEL-1:0] 	   exdst3,
+   input wire 			   kill_spec3,
+   input wire [`DATA_LEN-1:0] 	   exrslt4,
+   input wire [`RRF_SEL-1:0] 	   exdst4,
+   input wire 			   kill_spec4,
+   input wire [`DATA_LEN-1:0] 	   exrslt5,
+   input wire [`RRF_SEL-1:0] 	   exdst5,
+   input wire 			   kill_spec5
+   );
+
+   //_0
+   wire [`DATA_LEN-1:0] 	      ex_src1_0;
+   wire [`DATA_LEN-1:0] 	      ex_src2_0;
+   wire 			      ready_0;
+   wire [`ADDR_LEN-1:0] 	      pc_0;
+   wire [`DATA_LEN-1:0] 	      imm_0;
+   wire [`RRF_SEL-1:0] 		      rrftag_0;
+   wire 			      dstval_0;
+   wire [`SPECTAG_LEN-1:0] 	      spectag_0;
+   //_1
+   wire [`DATA_LEN-1:0] 	      ex_src1_1;
+   wire [`DATA_LEN-1:0] 	      ex_src2_1;
+   wire 			      ready_1;
+   wire [`ADDR_LEN-1:0] 	      pc_1;
+   wire [`DATA_LEN-1:0] 	      imm_1;
+   wire [`RRF_SEL-1:0] 		      rrftag_1;
+   wire 			      dstval_1;
+   wire [`SPECTAG_LEN-1:0] 	      spectag_1;
+   //_2
+   wire [`DATA_LEN-1:0] 	      ex_src1_2;
+   wire [`DATA_LEN-1:0] 	      ex_src2_2;
+   wire 			      ready_2;
+   wire [`ADDR_LEN-1:0] 	      pc_2;
+   wire [`DATA_LEN-1:0] 	      imm_2;
+   wire [`RRF_SEL-1:0] 		      rrftag_2;
+   wire 			      dstval_2;
+   wire [`SPECTAG_LEN-1:0] 	      spectag_2;
+   //_3
+   wire [`DATA_LEN-1:0] 	      ex_src1_3;
+   wire [`DATA_LEN-1:0] 	      ex_src2_3;
+   wire 			      ready_3;
+   wire [`ADDR_LEN-1:0] 	      pc_3;
+   wire [`DATA_LEN-1:0] 	      imm_3;
+   wire [`RRF_SEL-1:0] 		      rrftag_3;
+   wire 			      dstval_3;
+   wire [`SPECTAG_LEN-1:0] 	      spectag_3;
+   
+   reg [`LDST_ENT_NUM-1:0] 	   specbitvec;
+
+   //busy invalidation
+   wire [`LDST_ENT_NUM-1:0] 	   inv_vector =
+				   {(spectag_3 & specfixtag) == 0 ? 1'b1 : 1'b0,
+				    (spectag_2 & specfixtag) == 0 ? 1'b1 : 1'b0,
+				    (spectag_1 & specfixtag) == 0 ? 1'b1 : 1'b0,
+				    (spectag_0 & specfixtag) == 0 ? 1'b1 : 1'b0};
+
+   wire [`LDST_ENT_NUM-1:0] 	   inv_vector_spec =
+				   {(spectag_3 == prtag) ? 1'b0 : 1'b1,
+				    (spectag_2 == prtag) ? 1'b0 : 1'b1,
+				    (spectag_1 == prtag) ? 1'b0 : 1'b1,
+				    (spectag_0 == prtag) ? 1'b0 : 1'b1};
+
+   wire [`LDST_ENT_NUM-1:0] 	   specbitvec_next =
+				   (inv_vector_spec & specbitvec);
+   /*| 
+				   (we1 & wspecbit_1 ? (`LDST_ENT_SEL'b1 << waddr1) : 0) |
+				   (we2 & wspecbit_2 ? (`LDST_ENT_SEL'b1 << waddr2) : 0);
+    */
+   assign specbit = prsuccess ? 
+		    specbitvec_next[issueaddr] : specbitvec[issueaddr];
+   
+   assign ready = {ready_3, ready_2, ready_1, ready_0};
+   assign prbusyvec_next = inv_vector & busyvec;
+   
+   always @ (posedge clk) begin
+      if (reset) begin
+	 busyvec <= 0;
+	 specbitvec <= 0;
+      end else begin
+	 if (prmiss) begin
+	    busyvec <= prbusyvec_next;
+	    specbitvec <= 0;
+	 end else if (prsuccess) begin
+	    specbitvec <= specbitvec_next;
+	    /*
+	    if (we1) begin
+	       busyvec[waddr1] <= 1'b1;
+	    end
+	    if (we2) begin
+	       busyvec[waddr2] <= 1'b1;
+	    end
+	     */
+	    if (clearbusy) begin
+	       busyvec[issueaddr] <= 1'b0;
+	    end
+	 end else begin
+	    if (we1) begin
+	       busyvec[waddr1] <= 1'b1;
+	       specbitvec[waddr1] <= wspecbit_1;
+	    end
+	    if (we2) begin
+	       busyvec[waddr2] <= 1'b1;
+	       specbitvec[waddr2] <= wspecbit_2;
+	    end
+	    if (clearbusy) begin
+	       busyvec[issueaddr] <= 1'b0;
+	    end
+	 end
+      end
+   end
+
+   rs_ldst_ent ent0(
+		    .clk(clk),
+		    .reset(reset),
+		    .busy(busyvec[0]),
+		    .wpc((we1 && (waddr1 == 0)) ? wpc_1 : wpc_2),
+		    .wsrc1((we1 && (waddr1 == 0)) ? wsrc1_1 : wsrc1_2),
+		    .wsrc2((we1 && (waddr1 == 0)) ? wsrc2_1 : wsrc2_2),
+		    .wvalid1((we1 && (waddr1 == 0)) ? wvalid1_1 : wvalid1_2),
+		    .wvalid2((we1 && (waddr1 == 0)) ? wvalid2_1 : wvalid2_2),
+		    .wimm((we1 && (waddr1 == 0)) ? wimm_1 : wimm_2),
+		    .wrrftag((we1 && (waddr1 == 0)) ? wrrftag_1 : wrrftag_2),
+		    .wdstval((we1 && (waddr1 == 0)) ? wdstval_1 : wdstval_2),
+		    .wspectag((we1 && (waddr1 == 0)) ? wspectag_1 : wspectag_2),
+		    .we((we1 && (waddr1 == 0)) || (we2 && (waddr2 == 0))),
+		    .ex_src1(ex_src1_0),
+		    .ex_src2(ex_src2_0),
+		    .ready(ready_0),
+		    .pc(pc_0),
+		    .imm(imm_0),
+		    .rrftag(rrftag_0),
+		    .dstval(dstval_0),
+		    .spectag(spectag_0),
+		    .exrslt1(exrslt1),
+		    .exdst1(exdst1),
+		    .kill_spec1(kill_spec1),
+		    .exrslt2(exrslt2),
+		    .exdst2(exdst2),
+		    .kill_spec2(kill_spec2),
+		    .exrslt3(exrslt3),
+		    .exdst3(exdst3),
+		    .kill_spec3(kill_spec3),
+		    .exrslt4(exrslt4),
+		    .exdst4(exdst4),
+		    .kill_spec4(kill_spec4),
+		    .exrslt5(exrslt5),
+		    .exdst5(exdst5),
+		    .kill_spec5(kill_spec5)
+		    );
+
+   rs_ldst_ent ent1(
+		    .clk(clk),
+		    .reset(reset),		    
+		    .busy(busyvec[1]),
+		    .wpc((we1 && (waddr1 == 1)) ? wpc_1 : wpc_2),
+		    .wsrc1((we1 && (waddr1 == 1)) ? wsrc1_1 : wsrc1_2),
+		    .wsrc2((we1 && (waddr1 == 1)) ? wsrc2_1 : wsrc2_2),
+		    .wvalid1((we1 && (waddr1 == 1)) ? wvalid1_1 : wvalid1_2),
+		    .wvalid2((we1 && (waddr1 == 1)) ? wvalid2_1 : wvalid2_2),
+		    .wimm((we1 && (waddr1 == 1)) ? wimm_1 : wimm_2),
+		    .wrrftag((we1 && (waddr1 == 1)) ? wrrftag_1 : wrrftag_2),
+		    .wdstval((we1 && (waddr1 == 1)) ? wdstval_1 : wdstval_2),
+		    .wspectag((we1 && (waddr1 == 1)) ? wspectag_1 : wspectag_2),
+		    .we((we1 && (waddr1 == 1)) || (we2 && (waddr2 == 1))),
+		    .ex_src1(ex_src1_1),
+		    .ex_src2(ex_src2_1),
+		    .ready(ready_1),
+		    .pc(pc_1),
+		    .imm(imm_1),
+		    .rrftag(rrftag_1),
+		    .dstval(dstval_1),
+		    .spectag(spectag_1),
+		    .exrslt1(exrslt1),
+		    .exdst1(exdst1),
+		    .kill_spec1(kill_spec1),
+		    .exrslt2(exrslt2),
+		    .exdst2(exdst2),
+		    .kill_spec2(kill_spec2),
+		    .exrslt3(exrslt3),
+		    .exdst3(exdst3),
+		    .kill_spec3(kill_spec3),
+		    .exrslt4(exrslt4),
+		    .exdst4(exdst4),
+		    .kill_spec4(kill_spec4),
+		    .exrslt5(exrslt5),
+		    .exdst5(exdst5),
+		    .kill_spec5(kill_spec5)
+		    );
+
+   rs_ldst_ent ent2(
+		    .clk(clk),
+		    .reset(reset),		    
+		    .busy(busyvec[2]),
+		    .wpc((we1 && (waddr1 == 2)) ? wpc_1 : wpc_2),
+		    .wsrc1((we1 && (waddr1 == 2)) ? wsrc1_1 : wsrc1_2),
+		    .wsrc2((we1 && (waddr1 == 2)) ? wsrc2_1 : wsrc2_2),
+		    .wvalid1((we1 && (waddr1 == 2)) ? wvalid1_1 : wvalid1_2),
+		    .wvalid2((we1 && (waddr1 == 2)) ? wvalid2_1 : wvalid2_2),
+		    .wimm((we1 && (waddr1 == 2)) ? wimm_1 : wimm_2),
+		    .wrrftag((we1 && (waddr1 == 2)) ? wrrftag_1 : wrrftag_2),
+		    .wdstval((we1 && (waddr1 == 2)) ? wdstval_1 : wdstval_2),
+		    .wspectag((we1 && (waddr1 == 2)) ? wspectag_1 : wspectag_2),
+		    .we((we1 && (waddr1 == 2)) || (we2 && (waddr2 == 2))),
+		    .ex_src1(ex_src1_2),
+		    .ex_src2(ex_src2_2),
+		    .ready(ready_2),
+		    .pc(pc_2),
+		    .imm(imm_2),
+		    .rrftag(rrftag_2),
+		    .dstval(dstval_2),
+		    .spectag(spectag_2),
+		    .exrslt1(exrslt1),
+		    .exdst1(exdst1),
+		    .kill_spec1(kill_spec1),
+		    .exrslt2(exrslt2),
+		    .exdst2(exdst2),
+		    .kill_spec2(kill_spec2),
+		    .exrslt3(exrslt3),
+		    .exdst3(exdst3),
+		    .kill_spec3(kill_spec3),
+		    .exrslt4(exrslt4),
+		    .exdst4(exdst4),
+		    .kill_spec4(kill_spec4),
+		    .exrslt5(exrslt5),
+		    .exdst5(exdst5),
+		    .kill_spec5(kill_spec5)
+		    );
+
+   rs_ldst_ent ent3(
+		    .clk(clk),
+		    .reset(reset),		    
+		    .busy(busyvec[3]),
+		    .wpc((we1 && (waddr1 == 3)) ? wpc_1 : wpc_2),
+		    .wsrc1((we1 && (waddr1 == 3)) ? wsrc1_1 : wsrc1_2),
+		    .wsrc2((we1 && (waddr1 == 3)) ? wsrc2_1 : wsrc2_2),
+		    .wvalid1((we1 && (waddr1 == 3)) ? wvalid1_1 : wvalid1_2),
+		    .wvalid2((we1 && (waddr1 == 3)) ? wvalid2_1 : wvalid2_2),
+		    .wimm((we1 && (waddr1 == 3)) ? wimm_1 : wimm_2),
+		    .wrrftag((we1 && (waddr1 == 3)) ? wrrftag_1 : wrrftag_2),
+		    .wdstval((we1 && (waddr1 == 3)) ? wdstval_1 : wdstval_2),
+		    .wspectag((we1 && (waddr1 == 3)) ? wspectag_1 : wspectag_2),
+		    .we((we1 && (waddr1 == 3)) || (we2 && (waddr2 == 3))),
+		    .ex_src1(ex_src1_3),
+		    .ex_src2(ex_src2_3),
+		    .ready(ready_3),
+		    .pc(pc_3),
+		    .imm(imm_3),
+		    .rrftag(rrftag_3),
+		    .dstval(dstval_3),
+		    .spectag(spectag_3),
+		    .exrslt1(exrslt1),
+		    .exdst1(exdst1),
+		    .kill_spec1(kill_spec1),
+		    .exrslt2(exrslt2),
+		    .exdst2(exdst2),
+		    .kill_spec2(kill_spec2),
+		    .exrslt3(exrslt3),
+		    .exdst3(exdst3),
+		    .kill_spec3(kill_spec3),
+		    .exrslt4(exrslt4),
+		    .exdst4(exdst4),
+		    .kill_spec4(kill_spec4),
+		    .exrslt5(exrslt5),
+		    .exdst5(exdst5),
+		    .kill_spec5(kill_spec5)
+		    );
+
+   
+   assign ex_src1 = (issueaddr == 0) ? ex_src1_0 :
+		    (issueaddr == 1) ? ex_src1_1 :
+		    (issueaddr == 2) ? ex_src1_2 : ex_src1_3;
+
+   assign ex_src2 = (issueaddr == 0) ? ex_src2_0 :
+		    (issueaddr == 1) ? ex_src2_1 :
+		    (issueaddr == 2) ? ex_src2_2 : ex_src2_3;
+
+   assign pc = (issueaddr == 0) ? pc_0 :
+	       (issueaddr == 1) ? pc_1 :
+	       (issueaddr == 2) ? pc_2 : pc_3;
+
+   assign imm = (issueaddr == 0) ? imm_0 :
+		(issueaddr == 1) ? imm_1 :
+		(issueaddr == 2) ? imm_2 : imm_3;
+
+   assign rrftag = (issueaddr == 0) ? rrftag_0 :
+		   (issueaddr == 1) ? rrftag_1 :
+		   (issueaddr == 2) ? rrftag_2 : rrftag_3;
+
+   assign dstval = (issueaddr == 0) ? dstval_0 :
+		   (issueaddr == 1) ? dstval_1 :
+		   (issueaddr == 2) ? dstval_2 : dstval_3;
+
+   assign spectag = (issueaddr == 0) ? spectag_0 :
+		    (issueaddr == 1) ? spectag_1 :
+		    (issueaddr == 2) ? spectag_2 : spectag_3;
+   
+   
+endmodule // rs_ldst
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/rs_mul.v
+++ b/examples/SQED_ridecore/rtl/design/rs_mul.v
@@ -1,0 +1,400 @@
+`include "constants.vh"
+`include "alu_ops.vh"
+`default_nettype none
+module rs_mul_ent
+  (
+   //Memory
+   input wire 			 clk,
+   input wire 			 reset,
+   input wire 			 busy,
+   input wire [`DATA_LEN-1:0] 	 wsrc1,
+   input wire [`DATA_LEN-1:0] 	 wsrc2,
+   input wire 			 wvalid1,
+   input wire 			 wvalid2,
+   input wire [`RRF_SEL-1:0] 	 wrrftag,
+   input wire 			 wdstval,
+   input wire [`SPECTAG_LEN-1:0] 	 wspectag,
+   input wire 			 wsrc1_signed,
+   input wire 			 wsrc2_signed,
+   input wire 			 wsel_lohi,
+   input wire 			 we,
+   output wire [`DATA_LEN-1:0] 	 ex_src1,
+   output wire [`DATA_LEN-1:0] 	 ex_src2,
+   output wire 			 ready,
+   output reg [`RRF_SEL-1:0] 	 rrftag,
+   output reg 			 dstval,
+   output reg [`SPECTAG_LEN-1:0] spectag,
+   output reg 			 src1_signed,
+   output reg 			 src2_signed,
+   output reg 			 sel_lohi,
+   //EXRSLT
+   input wire [`DATA_LEN-1:0] 	 exrslt1,
+   input wire [`RRF_SEL-1:0] 	 exdst1,
+   input wire 			 kill_spec1,
+   input wire [`DATA_LEN-1:0] 	 exrslt2,
+   input wire [`RRF_SEL-1:0] 	 exdst2,
+   input wire 			 kill_spec2,
+   input wire [`DATA_LEN-1:0] 	 exrslt3,
+   input wire [`RRF_SEL-1:0] 	 exdst3,
+   input wire 			 kill_spec3,
+   input wire [`DATA_LEN-1:0] 	 exrslt4,
+   input wire [`RRF_SEL-1:0] 	 exdst4,
+   input wire 			 kill_spec4,
+   input wire [`DATA_LEN-1:0] 	 exrslt5,
+   input wire [`RRF_SEL-1:0] 	 exdst5,
+   input wire 			 kill_spec5
+   );
+
+   reg [`DATA_LEN-1:0] 		 src1;
+   reg [`DATA_LEN-1:0] 		 src2;
+   reg 				 valid1;
+   reg 				 valid2;
+
+   wire [`DATA_LEN-1:0] 	 nextsrc1;
+   wire [`DATA_LEN-1:0] 	 nextsrc2;   
+   wire 			 nextvalid1;
+   wire 			 nextvalid2;
+   
+   assign ready = busy & valid1 & valid2;
+   assign ex_src1 = ~valid1 & nextvalid1 ?
+		    nextsrc1 : src1;
+   assign ex_src2 = ~valid2 & nextvalid2 ?
+		    nextsrc2 : src2;
+   
+   always @ (posedge clk) begin
+      if (reset) begin
+	 rrftag <= 0;
+	 dstval <= 0;
+	 spectag <= 0;
+	 src1_signed <= 0;
+	 src2_signed <= 0;
+	 sel_lohi <= 0;
+
+	 src1 <= 0;
+	 src2 <= 0;
+	 valid1 <= 0;
+	 valid2 <= 0;
+      end else if (we) begin
+	 rrftag <= wrrftag;
+	 dstval <= wdstval;
+	 spectag <= wspectag;
+	 src1_signed <= wsrc1_signed;
+	 src2_signed <= wsrc2_signed;
+	 sel_lohi <= wsel_lohi;
+
+	 src1 <= wsrc1;
+	 src2 <= wsrc2;
+	 valid1 <= wvalid1;
+	 valid2 <= wvalid2;
+      end else begin // if (we)
+	 src1 <= nextsrc1;
+	 src2 <= nextsrc2;
+	 valid1 <= nextvalid1;
+	 valid2 <= nextvalid2;
+      end
+   end
+   
+   src_manager srcmng1(
+		       .opr(src1),
+		       .opr_rdy(valid1),
+		       .exrslt1(exrslt1),
+		       .exdst1(exdst1),
+		       .kill_spec1(kill_spec1),
+		       .exrslt2(exrslt2),
+		       .exdst2(exdst2),
+		       .kill_spec2(kill_spec2),
+		       .exrslt3(exrslt3),
+		       .exdst3(exdst3),
+		       .kill_spec3(kill_spec3),
+		       .exrslt4(exrslt4),
+		       .exdst4(exdst4),
+		       .kill_spec4(kill_spec4),
+		       .exrslt5(exrslt5),
+		       .exdst5(exdst5),
+		       .kill_spec5(kill_spec5),
+		       .src(nextsrc1),
+		       .resolved(nextvalid1)
+		       );
+
+   src_manager srcmng2(
+		       .opr(src2),
+		       .opr_rdy(valid2),
+		       .exrslt1(exrslt1),
+		       .exdst1(exdst1),
+		       .kill_spec1(kill_spec1),
+		       .exrslt2(exrslt2),
+		       .exdst2(exdst2),
+		       .kill_spec2(kill_spec2),
+		       .exrslt3(exrslt3),
+		       .exdst3(exdst3),
+		       .kill_spec3(kill_spec3),
+		       .exrslt4(exrslt4),
+		       .exdst4(exdst4),
+		       .kill_spec4(kill_spec4),
+		       .exrslt5(exrslt5),
+		       .exdst5(exdst5),
+		       .kill_spec5(kill_spec5),
+		       .src(nextsrc2),
+		       .resolved(nextvalid2)
+		       );
+   
+endmodule // rs_mul
+
+
+module rs_mul
+  (
+   //System
+   input wire 			  clk,
+   input wire 			  reset,
+   output reg [`MUL_ENT_NUM-1:0]  busyvec,
+   input wire 			  prmiss,
+   input wire 			  prsuccess,
+   input wire [`SPECTAG_LEN-1:0] 	  prtag,
+   input wire [`SPECTAG_LEN-1:0] 	  specfixtag,
+   //WriteSignal
+   input wire 			  clearbusy, //Issue 
+   input wire [`MUL_ENT_SEL-1:0] 	  issueaddr, //= raddr, clsbsyadr
+   input wire 			  we1, //alloc1
+   input wire 			  we2, //alloc2
+   input wire [`MUL_ENT_SEL-1:0] 	  waddr1, //allocent1
+   input wire [`MUL_ENT_SEL-1:0] 	  waddr2, //allocent2
+   //WriteSignal1
+   input wire [`DATA_LEN-1:0] 	  wsrc1_1,
+   input wire [`DATA_LEN-1:0] 	  wsrc2_1,
+   input wire 			  wvalid1_1,
+   input wire 			  wvalid2_1,
+   input wire [`RRF_SEL-1:0] 	  wrrftag_1,
+   input wire 			  wdstval_1,
+   input wire [`SPECTAG_LEN-1:0] 	  wspectag_1,
+   input wire 			  wspecbit_1,
+   input wire 			  wsrc1_signed_1,
+   input wire 			  wsrc2_signed_1,
+   input wire 			  wsel_lohi_1,
+
+   //WriteSignal2
+   input wire [`DATA_LEN-1:0] 	  wsrc1_2,
+   input wire [`DATA_LEN-1:0] 	  wsrc2_2,
+   input wire 			  wvalid1_2,
+   input wire 			  wvalid2_2,
+   input wire [`RRF_SEL-1:0] 	  wrrftag_2,
+   input wire 			  wdstval_2,
+   input wire [`SPECTAG_LEN-1:0] 	  wspectag_2,
+   input wire 			  wspecbit_2,
+   input wire 			  wsrc1_signed_2,
+   input wire 			  wsrc2_signed_2,
+   input wire 			  wsel_lohi_2,
+
+   //ReadSignal
+   output wire [`DATA_LEN-1:0] 	  ex_src1,
+   output wire [`DATA_LEN-1:0] 	  ex_src2,
+   output wire [`MUL_ENT_NUM-1:0] ready,
+   output wire [`RRF_SEL-1:0] 	  rrftag,
+   output wire 			  dstval,
+   output wire [`SPECTAG_LEN-1:0] spectag,
+   output wire 			  specbit,
+   output wire 			  src1_signed,
+   output wire 			  src2_signed,
+   output wire 			  sel_lohi,
+
+   //EXRSLT
+   input wire [`DATA_LEN-1:0] 	  exrslt1,
+   input wire [`RRF_SEL-1:0] 	  exdst1,
+   input wire 			  kill_spec1,
+   input wire [`DATA_LEN-1:0] 	  exrslt2,
+   input wire [`RRF_SEL-1:0] 	  exdst2,
+   input wire 			  kill_spec2,
+   input wire [`DATA_LEN-1:0] 	  exrslt3,
+   input wire [`RRF_SEL-1:0] 	  exdst3,
+   input wire 			  kill_spec3,
+   input wire [`DATA_LEN-1:0] 	  exrslt4,
+   input wire [`RRF_SEL-1:0] 	  exdst4,
+   input wire 			  kill_spec4,
+   input wire [`DATA_LEN-1:0] 	  exrslt5,
+   input wire [`RRF_SEL-1:0] 	  exdst5,
+   input wire 			  kill_spec5
+   );
+
+   //_0
+   wire [`DATA_LEN-1:0] 	      ex_src1_0;
+   wire [`DATA_LEN-1:0] 	      ex_src2_0;
+   wire 			      ready_0;
+   wire [`RRF_SEL-1:0] 		      rrftag_0;
+   wire 			      dstval_0;
+   wire [`SPECTAG_LEN-1:0] 	      spectag_0;
+   wire 			      src1_signed_0;
+   wire 			      src2_signed_0;
+   wire 			      sel_lohi_0;
+   
+   //_1
+   wire [`DATA_LEN-1:0] 	      ex_src1_1;
+   wire [`DATA_LEN-1:0] 	      ex_src2_1;
+   wire 			      ready_1;
+   wire [`RRF_SEL-1:0] 		      rrftag_1;
+   wire 			      dstval_1;
+   wire [`SPECTAG_LEN-1:0] 	      spectag_1;
+   wire 			      src1_signed_1;
+   wire 			      src2_signed_1;
+   wire 			      sel_lohi_1;
+
+   reg [`MUL_ENT_NUM-1:0] 	  specbitvec;
+
+   wire [`MUL_ENT_NUM-1:0] 	  inv_vector =
+				  {(spectag_1 & specfixtag) == 0 ? 1'b1 : 1'b0,
+				   (spectag_0 & specfixtag) == 0 ? 1'b1 : 1'b0};
+
+   wire [`MUL_ENT_NUM-1:0] 	  inv_vector_spec =
+				  {(spectag_1 == prtag) ? 1'b0 : 1'b1,
+				   (spectag_0 == prtag) ? 1'b0 : 1'b1};
+
+   wire [`MUL_ENT_NUM-1:0] 	  specbitvec_next =
+				  (inv_vector_spec & specbitvec);
+   /* |
+				  (we1 & wspecbit_1 ? (`MUL_ENT_SEL'b1 << waddr1) : 0) |
+				  (we2 & wspecbit_2 ? (`MUL_ENT_SEL'b1 << waddr2) : 0);
+    */
+   assign specbit = prsuccess ? 
+		    specbitvec_next[issueaddr] : specbitvec[issueaddr];
+
+   assign ready = {ready_1, ready_0};
+   
+   always @ (posedge clk) begin
+      if (reset) begin
+	 busyvec <= 0;
+	 specbitvec <= 0;
+      end else begin
+	 if (prmiss) begin
+	    busyvec <= inv_vector & busyvec;
+	    specbitvec <= 0;
+	 end else if (prsuccess) begin
+	    specbitvec <= specbitvec_next;
+	    /*
+	    if (we1) begin
+	       busyvec[waddr1] <= 1'b1;
+	    end
+	    if (we2) begin
+	       busyvec[waddr2] <= 1'b1;
+	    end
+	     */
+	    if (clearbusy) begin
+	       busyvec[issueaddr] <= 1'b0;
+	    end
+	 end else begin
+	    if (we1) begin
+	       busyvec[waddr1] <= 1'b1;
+	       specbitvec[waddr1] <= wspecbit_1;
+	    end
+	    if (we2) begin
+	       busyvec[waddr2] <= 1'b1;
+	       specbitvec[waddr2] <= wspecbit_2;
+	    end
+	    if (clearbusy) begin
+	       busyvec[issueaddr] <= 1'b0;
+	    end
+	 end
+      end
+   end
+
+   rs_mul_ent ent0(
+		   .clk(clk),
+		   .reset(reset),		      		   
+		   .busy(busyvec[0]),
+		   .wsrc1((we1 && (waddr1 == 0)) ? wsrc1_1 : wsrc1_2),
+		   .wsrc2((we1 && (waddr1 == 0)) ? wsrc2_1 : wsrc2_2),
+		   .wvalid1((we1 && (waddr1 == 0)) ? wvalid1_1 : wvalid1_2),
+		   .wvalid2((we1 && (waddr1 == 0)) ? wvalid2_1 : wvalid2_2),
+		   .wrrftag((we1 && (waddr1 == 0)) ? wrrftag_1 : wrrftag_2),
+		   .wdstval((we1 && (waddr1 == 0)) ? wdstval_1 : wdstval_2),
+		   .wspectag((we1 && (waddr1 == 0)) ? wspectag_1 : wspectag_2),
+		   .wsrc1_signed((we1 && (waddr1 == 0)) ? wsrc1_signed_1 : wsrc1_signed_2),
+		   .wsrc2_signed((we1 && (waddr1 == 0)) ? wsrc2_signed_1 : wsrc2_signed_2),
+		   .wsel_lohi((we1 && (waddr1 == 0)) ? wsel_lohi_1 : wsel_lohi_2),
+		   .we((we1 && (waddr1 == 0)) || (we2 && (waddr2 == 0))),
+		   .ex_src1(ex_src1_0),
+		   .ex_src2(ex_src2_0),
+		   .ready(ready_0),
+		   .rrftag(rrftag_0),
+		   .dstval(dstval_0),
+		   .spectag(spectag_0),
+		   .src1_signed(src1_signed_0),
+		   .src2_signed(src2_signed_0),
+		   .sel_lohi(sel_lohi_0),
+		   .exrslt1(exrslt1),
+		   .exdst1(exdst1),
+		   .kill_spec1(kill_spec1),
+		   .exrslt2(exrslt2),
+		   .exdst2(exdst2),
+		   .kill_spec2(kill_spec2),
+		   .exrslt3(exrslt3),
+		   .exdst3(exdst3),
+		   .kill_spec3(kill_spec3),
+		   .exrslt4(exrslt4),
+		   .exdst4(exdst4),
+		   .kill_spec4(kill_spec4),
+		   .exrslt5(exrslt5),
+		   .exdst5(exdst5),
+		   .kill_spec5(kill_spec5)
+		   );
+
+   rs_mul_ent ent1(
+		   .clk(clk),
+		   .reset(reset),		   
+		   .busy(busyvec[1]),
+		   .wsrc1((we1 && (waddr1 == 1)) ? wsrc1_1 : wsrc1_2),
+		   .wsrc2((we1 && (waddr1 == 1)) ? wsrc2_1 : wsrc2_2),
+		   .wvalid1((we1 && (waddr1 == 1)) ? wvalid1_1 : wvalid1_2),
+		   .wvalid2((we1 && (waddr1 == 1)) ? wvalid2_1 : wvalid2_2),
+		   .wrrftag((we1 && (waddr1 == 1)) ? wrrftag_1 : wrrftag_2),
+		   .wdstval((we1 && (waddr1 == 1)) ? wdstval_1 : wdstval_2),
+		   .wspectag((we1 && (waddr1 == 1)) ? wspectag_1 : wspectag_2),
+			//EDIT: Mutation Testing
+		//    .wsrc1_signed((we1 && (waddr1 == 0)) ? wsrc1_signed_1 : wsrc1_signed_2),
+		//    .wsrc2_signed((we1 && (waddr1 == 0)) ? wsrc2_signed_1 : wsrc2_signed_2),
+		//    .wsel_lohi((we1 && (waddr1 == 0)) ? wsel_lohi_1 : wsel_lohi_2),
+		   .wsrc1_signed((we1 && (waddr1 == 1)) ? wsrc1_signed_1 : wsrc1_signed_2),
+		   .wsrc2_signed((we1 && (waddr1 == 1)) ? wsrc2_signed_1 : wsrc2_signed_2),
+		   .wsel_lohi((we1 && (waddr1 == 1)) ? wsel_lohi_1 : wsel_lohi_2),
+		   //EDIT: END
+		   .we((we1 && (waddr1 == 1)) || (we2 && (waddr2 == 1))),
+		   .ex_src1(ex_src1_1),
+		   .ex_src2(ex_src2_1),
+		   .ready(ready_1),
+		   .rrftag(rrftag_1),
+		   .dstval(dstval_1),
+		   .spectag(spectag_1),
+		   .src1_signed(src1_signed_1),
+		   .src2_signed(src2_signed_1),
+		   .sel_lohi(sel_lohi_1),
+		   .exrslt1(exrslt1),
+		   .exdst1(exdst1),
+		   .kill_spec1(kill_spec1),
+		   .exrslt2(exrslt2),
+		   .exdst2(exdst2),
+		   .kill_spec2(kill_spec2),
+		   .exrslt3(exrslt3),
+		   .exdst3(exdst3),
+		   .kill_spec3(kill_spec3),
+		   .exrslt4(exrslt4),
+		   .exdst4(exdst4),
+		   .kill_spec4(kill_spec4),
+		   .exrslt5(exrslt5),
+		   .exdst5(exdst5),
+		   .kill_spec5(kill_spec5)
+		   );
+   
+   assign ex_src1 = (issueaddr == 0) ? ex_src1_0 : ex_src1_1;
+   
+   assign ex_src2 = (issueaddr == 0) ? ex_src2_0 : ex_src2_1;
+
+   assign rrftag = (issueaddr == 0) ? rrftag_0 : rrftag_1;
+   
+   assign dstval = (issueaddr == 0) ? dstval_0 : dstval_1;
+
+   assign spectag = (issueaddr == 0) ? spectag_0 : spectag_1;
+
+   assign src1_signed = (issueaddr == 0) ? src1_signed_0 : src1_signed_1;
+
+   assign src2_signed = (issueaddr == 0) ? src2_signed_0 : src2_signed_1;
+
+   assign sel_lohi = (issueaddr == 0) ? sel_lohi_0 : sel_lohi_1;   
+endmodule // rs_mul
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/rs_reqgen.v
+++ b/examples/SQED_ridecore/rtl/design/rs_reqgen.v
@@ -1,0 +1,38 @@
+`include "constants.vh"
+`default_nettype none
+module rs_requestgenerator
+  (
+   input wire [`RS_ENT_SEL-1:0] rsent_1,
+   input wire [`RS_ENT_SEL-1:0] rsent_2,
+   output wire 			req1_alu,
+   output wire 			req2_alu,
+   output wire [1:0] 		req_alunum,
+   output wire 			req1_branch,
+   output wire 			req2_branch,
+   output wire [1:0] 		req_branchnum,
+   output wire 			req1_mul,
+   output wire 			req2_mul,
+   output wire [1:0] 		req_mulnum,
+   output wire 			req1_ldst,
+   output wire 			req2_ldst,
+   output wire [1:0] 		req_ldstnum
+   );
+
+   assign req1_alu = (rsent_1 == `RS_ENT_ALU) ? 1'b1 : 1'b0;
+   assign req2_alu = (rsent_2 == `RS_ENT_ALU) ? 1'b1 : 1'b0;
+   assign req_alunum = {1'b0, req1_alu} + {1'b0, req2_alu};
+
+   assign req1_branch = (rsent_1 == `RS_ENT_BRANCH) ? 1'b1 : 1'b0;
+   assign req2_branch = (rsent_2 == `RS_ENT_BRANCH) ? 1'b1 : 1'b0;
+   assign req_branchnum = {1'b0, req1_branch} + {1'b0, req2_branch};
+
+   assign req1_mul = (rsent_1 == `RS_ENT_MUL) ? 1'b1 : 1'b0;
+   assign req2_mul = (rsent_2 == `RS_ENT_MUL) ? 1'b1 : 1'b0;
+   assign req_mulnum = {1'b0, req1_mul} + {1'b0, req2_mul};
+
+   assign req1_ldst = (rsent_1 == `RS_ENT_LDST) ? 1'b1 : 1'b0;
+   assign req2_ldst = (rsent_2 == `RS_ENT_LDST) ? 1'b1 : 1'b0;
+   assign req_ldstnum = {1'b0, req1_ldst} + {1'b0, req2_ldst};
+   
+endmodule // rs_requestgenerator
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/rv32_opcodes.vh
+++ b/examples/SQED_ridecore/rtl/design/rv32_opcodes.vh
@@ -1,0 +1,98 @@
+// Width-related constants
+`define INST_WIDTH     32
+`define REG_ADDR_WIDTH  5
+`define XPR_LEN        32
+`define DOUBLE_XPR_LEN 64
+`define LOG2_XPR_LEN    5
+`define SHAMT_WIDTH     5
+
+`define RV_NOP `INST_WIDTH'b0010011
+
+// Opcodes
+
+`define RV32_LOAD     7'b0000011
+`define RV32_STORE    7'b0100011
+`define RV32_MADD     7'b1000011
+`define RV32_BRANCH   7'b1100011
+
+`define RV32_LOAD_FP  7'b0000111
+`define RV32_STORE_FP 7'b0100111 
+`define RV32_MSUB     7'b1000111
+`define RV32_JALR     7'b1100111
+
+`define RV32_CUSTOM_0 7'b0001011
+`define RV32_CUSTOM_1 7'b0101011
+`define RV32_NMSUB    7'b1001011
+// 7'b1101011 is reserved
+
+`define RV32_MISC_MEM 7'b0001111
+`define RV32_AMO      7'b0101111
+`define RV32_NMADD    7'b1001111
+`define RV32_JAL      7'b1101111
+
+`define RV32_OP_IMM   7'b0010011
+`define RV32_OP       7'b0110011
+`define RV32_OP_FP    7'b1010011
+`define RV32_SYSTEM   7'b1110011
+
+`define RV32_AUIPC    7'b0010111
+`define RV32_LUI      7'b0110111
+// 7'b1010111 is reserved
+// 7'b1110111 is reserved
+
+// 7'b0011011 is RV64-specific
+// 7'b0111011 is RV64-specific
+`define RV32_CUSTOM_2 7'b1011011
+`define RV32_CUSTOM_3 7'b1111011
+
+// Arithmetic FUNCT3 encodings
+
+`define RV32_FUNCT3_ADD_SUB 0
+`define RV32_FUNCT3_SLL     1
+`define RV32_FUNCT3_SLT     2
+`define RV32_FUNCT3_SLTU    3
+`define RV32_FUNCT3_XOR     4
+`define RV32_FUNCT3_SRA_SRL 5
+`define RV32_FUNCT3_OR      6
+`define RV32_FUNCT3_AND     7
+
+// Branch FUNCT3 encodings
+
+`define RV32_FUNCT3_BEQ  0
+`define RV32_FUNCT3_BNE  1
+`define RV32_FUNCT3_BLT  4
+`define RV32_FUNCT3_BGE  5
+`define RV32_FUNCT3_BLTU 6
+`define RV32_FUNCT3_BGEU 7
+
+// MISC-MEM FUNCT3 encodings
+`define RV32_FUNCT3_FENCE   0
+`define RV32_FUNCT3_FENCE_I 1
+
+// SYSTEM FUNCT3 encodings
+
+`define RV32_FUNCT3_PRIV   0
+`define RV32_FUNCT3_CSRRW  1
+`define RV32_FUNCT3_CSRRS  2
+`define RV32_FUNCT3_CSRRC  3
+`define RV32_FUNCT3_CSRRWI 5
+`define RV32_FUNCT3_CSRRSI 6
+`define RV32_FUNCT3_CSRRCI 7
+
+// PRIV FUNCT12 encodings
+
+`define RV32_FUNCT12_ECALL  12'b000000000000
+`define RV32_FUNCT12_EBREAK 12'b000000000001
+`define RV32_FUNCT12_ERET   12'b000100000000
+
+// RV32M encodings
+`define RV32_FUNCT7_MUL_DIV 7'd1
+
+`define RV32_FUNCT3_MUL    3'd0
+`define RV32_FUNCT3_MULH   3'd1
+`define RV32_FUNCT3_MULHSU 3'd2
+`define RV32_FUNCT3_MULHU  3'd3
+`define RV32_FUNCT3_DIV    3'd4
+`define RV32_FUNCT3_DIVU   3'd5
+`define RV32_FUNCT3_REM    3'd6
+`define RV32_FUNCT3_REMU   3'd7

--- a/examples/SQED_ridecore/rtl/design/search_be.v
+++ b/examples/SQED_ridecore/rtl/design/search_be.v
@@ -1,0 +1,48 @@
+
+module search_begin #(
+		      parameter ENTSEL = 2,
+		      parameter ENTNUM = 4
+		     )
+  (
+   input wire [ENTNUM-1:0] in,
+   output reg [ENTSEL-1:0] out,
+   output reg 		   en
+   );
+
+   integer 		   i;
+   always @ (*) begin
+      out = 0;
+      en = 0;
+      for (i = ENTNUM-1; i >= 0 ; i = i - 1) begin
+	 if (in[i]) begin
+	    out = i;
+	    en = 1;
+	 end
+      end
+   end
+   
+endmodule // search_from_top
+
+module search_end #(
+		    parameter ENTSEL = 2,
+		    parameter ENTNUM = 4
+		    )
+   (
+    input wire [ENTNUM-1:0] in,
+    output reg [ENTSEL-1:0] out,
+    output reg 		    en
+   );
+
+   integer 		   i;
+   always @ (*) begin
+      out = 0;
+      en = 0;
+      for (i = 0 ; i < ENTNUM ; i = i + 1) begin
+	 if (in[i]) begin
+	    out = i;
+	    en = 1;
+	 end
+      end
+   end
+
+endmodule // search_from_bottom

--- a/examples/SQED_ridecore/rtl/design/src_manager.v
+++ b/examples/SQED_ridecore/rtl/design/src_manager.v
@@ -1,0 +1,43 @@
+`include "constants.vh"
+`default_nettype none
+module src_manager
+  (
+   input wire [`DATA_LEN-1:0]  opr,
+   input wire 		       opr_rdy,
+   input wire [`DATA_LEN-1:0]  exrslt1,
+   input wire [`RRF_SEL-1:0]   exdst1,
+   input wire 		       kill_spec1,
+   input wire [`DATA_LEN-1:0]  exrslt2,
+   input wire [`RRF_SEL-1:0]   exdst2,
+   input wire 		       kill_spec2,
+   input wire [`DATA_LEN-1:0]  exrslt3,
+   input wire [`RRF_SEL-1:0]   exdst3,
+   input wire 		       kill_spec3,
+   input wire [`DATA_LEN-1:0]  exrslt4,
+   input wire [`RRF_SEL-1:0]   exdst4,
+   input wire 		       kill_spec4,
+   input wire [`DATA_LEN-1:0]  exrslt5,
+   input wire [`RRF_SEL-1:0]   exdst5,
+   input wire 		       kill_spec5,
+   output wire [`DATA_LEN-1:0] src,
+   output wire 		       resolved
+   );
+
+   assign src = opr_rdy ? opr :
+		~kill_spec1 & (exdst1 == opr) ? exrslt1 :
+		~kill_spec2 & (exdst2 == opr) ? exrslt2 :
+		~kill_spec3 & (exdst3 == opr) ? exrslt3 :
+		~kill_spec4 & (exdst4 == opr) ? exrslt4 :
+		~kill_spec5 & (exdst5 == opr) ? exrslt5 : opr;
+
+   assign resolved = opr_rdy |
+		     (~kill_spec1 & (exdst1 == opr)) |
+		     (~kill_spec2 & (exdst2 == opr)) |
+		     (~kill_spec3 & (exdst3 == opr)) |
+		     (~kill_spec4 & (exdst4 == opr)) |
+		     (~kill_spec5 & (exdst5 == opr));
+   
+endmodule // src_manager
+
+
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/srcopr_manager.v
+++ b/examples/SQED_ridecore/rtl/design/srcopr_manager.v
@@ -1,0 +1,25 @@
+`include "constants.vh"
+`default_nettype none
+module sourceoperand_manager
+  (
+   input wire [`DATA_LEN-1:0]  arfdata,
+   input wire 		       arf_busy,
+   input wire 		       rrf_valid,
+   input wire [`RRF_SEL-1:0]   rrftag,
+   input wire [`DATA_LEN-1:0]  rrfdata,
+   input wire [`RRF_SEL-1:0]   dst1_renamed,
+   input wire 		       src_eq_dst1,
+   input wire 		       src_eq_0,
+   output wire [`DATA_LEN-1:0] src,
+   output wire 		       rdy
+   );
+
+   assign src = src_eq_0 ? `DATA_LEN'b0 :
+		src_eq_dst1 ? dst1_renamed :
+		~arf_busy ? arfdata :
+		rrf_valid ? rrfdata :
+		rrftag;
+   assign rdy = src_eq_0 | (~src_eq_dst1 & (~arf_busy | rrf_valid));
+
+endmodule // sourceoperand_manager
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/srcsel.v
+++ b/examples/SQED_ridecore/rtl/design/srcsel.v
@@ -1,0 +1,41 @@
+`include "rv32_opcodes.vh"
+`include "constants.vh"
+`default_nettype none
+module src_a_mux(
+                 input wire [`SRC_A_SEL_WIDTH-1:0] src_a_sel,
+                 input wire [`ADDR_LEN-1:0] 	   pc,
+                 input wire [`DATA_LEN-1:0] 	   rs1,
+                 output reg [`DATA_LEN-1:0] 	   alu_src_a
+                 );
+
+
+   always @(*) begin
+      case (src_a_sel)
+        `SRC_A_RS1 : alu_src_a = rs1;
+        `SRC_A_PC : alu_src_a = pc;
+        default : alu_src_a = 0;
+      endcase // case (src_a_sel)
+   end
+
+endmodule // src_a_mux
+
+
+module src_b_mux(
+                 input wire [`SRC_B_SEL_WIDTH-1:0] src_b_sel,
+                 input wire [`DATA_LEN-1:0] 	   imm,
+                 input wire [`DATA_LEN-1:0] 	   rs2,
+                 output reg [`DATA_LEN-1:0] 	   alu_src_b
+                 );
+
+
+   always @(*) begin
+      case (src_b_sel)
+        `SRC_B_RS2 : alu_src_b = rs2;
+        `SRC_B_IMM : alu_src_b = imm;
+        `SRC_B_FOUR : alu_src_b = 4;
+        default : alu_src_b = 0;
+      endcase // case (src_b_sel)
+   end
+
+endmodule // src_b_mux
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/storebuf.v
+++ b/examples/SQED_ridecore/rtl/design/storebuf.v
@@ -1,0 +1,167 @@
+`include "constants.vh"
+
+module storebuf
+  (
+   input wire 			 clk,
+   input wire 			 reset,
+   input wire 			 prsuccess,
+   input wire 			 prmiss,
+   input wire [`SPECTAG_LEN-1:0] prtag,
+   input wire [`SPECTAG_LEN-1:0] spectagfix,
+   input wire 			 stfin,
+   input wire 			 stspecbit,
+   input wire [`SPECTAG_LEN-1:0] stspectag,
+   input wire [`DATA_LEN-1:0] 	 stdata,
+   input wire [`ADDR_LEN-1:0] 	 staddr,
+   input wire 			 stcom,
+   output wire 			 stretire, //dmem_we
+   output wire [`DATA_LEN-1:0] 	 retdata,
+   output wire [`ADDR_LEN-1:0] 	 retaddr,
+   input wire 			 memoccupy_ld,
+   output wire 			 sb_full,
+   //ReadSigs
+   input wire [`ADDR_LEN-1:0] 	 ldaddr,
+   output wire [`DATA_LEN-1:0] 	 lddata,
+   output wire 			 hit
+   );
+
+   reg [`STBUF_ENT_SEL-1:0] 	 finptr;
+   reg [`STBUF_ENT_SEL-1:0] 	 comptr;
+   reg [`STBUF_ENT_SEL-1:0] 	 retptr;
+   
+   reg [`SPECTAG_LEN-1:0] 	 spectag [0:`STBUF_ENT_NUM-1];
+   reg [`STBUF_ENT_NUM-1:0] 	 completed;
+   reg [`STBUF_ENT_NUM-1:0] 	 valid;
+   reg [`STBUF_ENT_NUM-1:0] 	 specbit;
+   reg [`DATA_LEN-1:0] 		 data [0:`STBUF_ENT_NUM-1];
+   reg [`ADDR_LEN-1:0] 		 addr [0:`STBUF_ENT_NUM-1];
+
+   //when prsuccess, specbit_next = specbit & specbitcls
+   wire [`STBUF_ENT_NUM-1:0] 	 specbit_cls;
+   wire [`STBUF_ENT_NUM-1:0] 	 valid_cls;
+   wire 			 notfull_next;
+   wire 			 notempty_next;
+   wire [`STBUF_ENT_SEL-1:0] 	 nb1;
+   wire [`STBUF_ENT_SEL-1:0] 	 ne1;
+   wire [`STBUF_ENT_SEL-1:0] 	 nb0;
+   wire [`STBUF_ENT_SEL-1:0] 	 finptr_next;
+   //For CAM with Priority
+   wire [`STBUF_ENT_NUM-1:0] 	 hitvec;
+   wire [2*`STBUF_ENT_NUM-1:0] 	 hitvec_rot;
+   wire [`STBUF_ENT_SEL-1:0] 	 ldent_rot;
+   wire [`STBUF_ENT_SEL-1:0] 	 ldent;
+   wire [`STBUF_ENT_SEL-1:0] 	 vecshamt;
+   
+   search_begin #(`STBUF_ENT_SEL, `STBUF_ENT_NUM) 
+   snb1(
+	.in(valid & valid_cls),
+	.out(nb1),
+	.en()
+	);
+   
+   search_end #(`STBUF_ENT_SEL, `STBUF_ENT_NUM) 
+   sne1(
+	.in(valid & valid_cls),
+	.out(ne1),
+	.en(notempty_next)
+	);
+
+   search_begin #(`STBUF_ENT_SEL, `STBUF_ENT_NUM) 
+   snb0(
+	.in(~(valid & valid_cls)),
+	.out(nb0),
+	.en(notfull_next)
+	);
+
+   search_end #(`STBUF_ENT_SEL, `STBUF_ENT_NUM)
+   findhitent(
+	      .in(hitvec_rot[2*`STBUF_ENT_NUM-1:`STBUF_ENT_NUM]),
+	      .out(ldent_rot),
+	      .en(hit)
+	      );
+   
+   assign retdata = data[retptr];
+   assign retaddr = addr[retptr];
+   assign lddata = data[ldent];
+   assign stretire = valid[retptr] && completed[retptr] && ~memoccupy_ld &&
+		     ~prmiss;
+   assign sb_full = ((finptr == retptr) && (valid[finptr] == 1)) ? 1'b1 : 1'b0;
+   assign finptr_next = (~notfull_next | ~notempty_next) ? finptr :
+			(((nb1 == 0) && (ne1 == `STBUF_ENT_NUM-1)) ? nb0 : (ne1+1));
+   assign vecshamt = (`STBUF_ENT_NUM - finptr);
+   assign hitvec_rot = {hitvec, hitvec} << vecshamt;
+   assign ldent = ldent_rot + finptr;
+   
+   generate
+      genvar 			 i;
+      for (i = 0 ; i < `STBUF_ENT_NUM ; i = i + 1) 
+	begin: L1
+	   assign specbit_cls[i] = (prtag == spectag[i]) ? 1'b0 : 1'b1;
+	   assign valid_cls[i] = (specbit[i] && ((spectagfix & spectag[i]) != 0)) ? 
+				 1'b0 : 1'b1;
+	   assign hitvec[i] = (valid[i] && (addr[i] == ldaddr)) ? 1'b1 : 1'b0;
+	end
+   endgenerate
+
+   always @ (posedge clk) begin
+      if (~reset & stfin) begin
+	 data[finptr] <= stdata;
+	 addr[finptr] <= staddr;
+	 spectag[finptr] <= stspectag;
+      end
+   end
+   
+   always @ (posedge clk) begin
+      if (reset) begin
+	 finptr <= 0;
+	 comptr <= 0;
+	 retptr <= 0;
+	 valid <= 0;
+	 completed <= 0;
+      end else if (prmiss) begin
+	 if (stfin) begin
+	    //KillNotOccur!!!
+	    finptr <= finptr + 1;
+	    valid[finptr] <= 1'b1;
+	    completed[finptr] <= 1'b0;
+	    comptr <= comptr;
+	    retptr <= retptr;
+	 end else begin
+	    valid <= valid & valid_cls;
+	    finptr <= finptr_next;
+	    comptr <= ~notempty_next ? finptr : comptr;
+	    retptr <= ~notempty_next ? finptr : retptr;
+	 end
+      end else begin
+	 if (stfin) begin
+	    finptr <= finptr + 1;
+	    valid[finptr] <= 1'b1;
+	    completed[finptr] <= 1'b0;
+	 end
+	 if (stcom) begin
+	    comptr <= comptr + 1;
+	    completed[comptr] <= 1'b1;
+	 end
+	 if (stretire) begin
+	    retptr <= retptr + 1;
+	    valid[retptr] <= 1'b0;
+	    completed[retptr] <= 1'b0;
+	 end
+      end
+   end // always @ (posedge clk)
+
+   always @ (posedge clk) begin
+      if (reset | prmiss) begin
+	 specbit <= 0;
+      end else if (prsuccess) begin
+	 specbit <= (specbit & specbit_cls) |
+		    (stfin ? 
+		     ({`STBUF_ENT_NUM{stspecbit}} << finptr) : 
+		     `STBUF_ENT_NUM'b0);
+      end else begin
+	 if (stfin) begin
+	    specbit[finptr] <= stspecbit;
+	 end
+      end
+   end
+endmodule // storebuf

--- a/examples/SQED_ridecore/rtl/design/system.v
+++ b/examples/SQED_ridecore/rtl/design/system.v
@@ -1,0 +1,184 @@
+/**************************************************************************************************/
+/* Many-core processor project Arch Lab.                                               TOKYO TECH */
+/**************************************************************************************************/
+`default_nettype none
+/**************************************************************************************************/
+`include "define.v"
+/**************************************************************************************************/
+
+module CLKGEN_DCM(CLK_IN, CLK_OUT, LOCKED);
+    input wire  CLK_IN;
+    output wire CLK_OUT, LOCKED;
+
+    wire clk_ibuf;
+    wire clk_out;
+    wire clk0, clk0_fbuf;
+
+    // input buffer
+    IBUFG ibuf (.I(CLK_IN),
+                .O(clk_ibuf));
+    // output buffer
+    BUFG  obuf (.I(clk_out),
+                .O(CLK_OUT));
+    // feedback buffer
+    BUFG  fbuf (.I(clk0),
+                .O(clk0_fbuf));
+
+    // dcm instantiation
+    DCM_SP dcm (// input
+                .CLKIN   (clk_ibuf),
+                .RST     (1'b0),
+                // output
+                .CLKFX   (clk_out),
+                .LOCKED  (LOCKED),
+                // feedback
+                .CLK0    (clk0),
+                .CLKFB   (clk0_fbuf), 
+                // phase shift
+                .PSEN    (1'b0),
+                .PSINCDEC(1'b0),
+                .PSCLK   (1'b0),
+                // digital spread spectrum
+                .DSSEN   (1'b0));
+
+    defparam dcm.CLKIN_PERIOD   = `DCM_CLKIN_PERIOD;
+    defparam dcm.CLKFX_MULTIPLY = `DCM_CLKFX_MULTIPLY;
+    defparam dcm.CLKFX_DIVIDE   = `DCM_CLKFX_DIVIDE;
+endmodule
+
+/**************************************************************************************************/
+
+module CLKGEN_MMCM(CLK_IN, CLK_OUT, LOCKED);
+    input wire  CLK_IN;
+    output wire CLK_OUT, LOCKED;
+
+    wire clk_out;
+    wire clkfb, clkfb_fbuf;
+
+    // output buffer
+    BUFG  obuf (.I(clk_out),
+                .O(CLK_OUT));
+    // feedback buffer
+    BUFG  fbuf (.I(clkfb),
+                .O(clkfb_fbuf));
+
+    MMCME2_ADV mmcm (// input
+				     .CLKIN1       (CLK_IN),
+				     .CLKIN2       (1'b0),
+				     .CLKINSEL     (1'b1),
+				     .RST          (1'b0),
+				     .PWRDWN       (1'b0),
+				  	 // output
+				     .CLKOUT0      (clk_out),
+				     .CLKOUT0B     (),
+				     .CLKOUT1      (),
+				     .CLKOUT1B     (),
+				     .CLKOUT2      (),
+				     .CLKOUT2B     (),
+				     .CLKOUT3      (),
+				     .CLKOUT3B     (),
+				     .CLKOUT4      (),
+				     .CLKOUT5      (),
+				     .CLKOUT6      (),
+				     .LOCKED       (LOCKED),
+                     // feedback
+				     .CLKFBOUT     (clkfb),
+				     .CLKFBIN      (clkfb_fbuf),
+				     .CLKFBOUTB    (),
+				     // dynamic reconfiguration
+				     .DADDR        (7'h0),
+				     .DI           (16'h0),
+				     .DWE          (1'b0),
+				     .DEN          (1'b0),
+				     .DCLK         (1'b0),
+				     .DO           (),
+				     .DRDY         (),
+				     // phase shift
+				     .PSCLK        (1'b0),
+				     .PSEN         (1'b0),
+				     .PSINCDEC     (1'b0),
+				     .PSDONE       (),
+				     // status
+				     .CLKINSTOPPED (),
+				     .CLKFBSTOPPED ());
+
+    defparam mmcm.CLKIN1_PERIOD    = `MMCM_CLKIN1_PERIOD;
+    defparam mmcm.CLKFBOUT_MULT_F  = `MMCM_VCO_MULTIPLY;
+    defparam mmcm.DIVCLK_DIVIDE    = `MMCM_VCO_DIVIDE;
+    defparam mmcm.CLKOUT0_DIVIDE_F = `MMCM_CLKOUT0_DIVIDE;
+    defparam mmcm.CLKOUT1_DIVIDE   = `MMCM_CLKOUT1_DIVIDE;
+endmodule
+
+/**************************************************************************************************/
+
+module RSTGEN(CLK, RST_X_I, RST_X_O);
+    input wire  CLK, RST_X_I;
+    output wire RST_X_O;
+
+    reg [7:0] cnt;
+    assign RST_X_O = cnt[7];
+
+    always @(posedge CLK or negedge RST_X_I) begin
+        if      (!RST_X_I) cnt <= 0;
+        else if (~RST_X_O) cnt <= (cnt + 1'b1);
+    end
+endmodule
+
+/**************************************************************************************************/
+
+module GEN_DCM(CLK_I, RST_X_I, CLK_O, RST_X_O);
+    input wire  CLK_I, RST_X_I;
+    output wire CLK_O, RST_X_O;
+    
+    wire LOCKED;
+    
+    CLKGEN_DCM clkgen(.CLK_IN (CLK_I),
+                      .CLK_OUT(CLK_O),
+                      .LOCKED (LOCKED));
+    RSTGEN     rstgen(.CLK    (CLK_O),
+                      .RST_X_I(RST_X_I & LOCKED),
+                      .RST_X_O(RST_X_O));
+endmodule
+
+module GEN_MMCM(CLK_I, RST_X_I, CLK_O, RST_X_O);
+    input wire  CLK_I, RST_X_I;
+    output wire CLK_O, RST_X_O;
+    
+    wire clk_ibuf;
+    wire LOCKED;
+
+    // input buffer
+    IBUFG ibuf (.I(CLK_I),
+                .O(clk_ibuf));
+
+    CLKGEN_MMCM clkgen(.CLK_IN (clk_ibuf),
+                       .CLK_OUT(CLK_O),
+                       .LOCKED (LOCKED));
+    RSTGEN      rstgen(.CLK    (CLK_O),
+                       .RST_X_I(RST_X_I & LOCKED),
+                       .RST_X_O(RST_X_O));
+endmodule
+
+module GEN_MMCM_DS(CLK_P, CLK_N, RST_X_I, CLK_O, RST_X_O);
+    input wire  CLK_P, CLK_N, RST_X_I;
+    output wire CLK_O, RST_X_O;
+
+    wire clk_ibuf;
+    wire LOCKED;
+
+    // input buffer
+    IBUFGDS ibuf (.I (CLK_P),
+                  .IB(CLK_N),
+                  .O (clk_ibuf));
+
+    CLKGEN_MMCM clkgen(.CLK_IN (clk_ibuf),
+                       .CLK_OUT(CLK_O),
+                       .LOCKED (LOCKED));
+    RSTGEN      rstgen(.CLK    (CLK_O),
+                       .RST_X_I(RST_X_I & LOCKED),
+                       .RST_X_O(RST_X_O));
+endmodule
+
+/**************************************************************************************************/
+`default_nettype wire
+/**************************************************************************************************/

--- a/examples/SQED_ridecore/rtl/design/tag_generator.v
+++ b/examples/SQED_ridecore/rtl/design/tag_generator.v
@@ -1,0 +1,49 @@
+`include "constants.vh"
+`default_nettype none
+module tag_generator(
+		     input wire 		    clk,
+		     input wire 		    reset,
+		     input wire 		    branchvalid1,
+		     input wire 		    branchvalid2,
+		     input wire 		    prmiss,
+		     input wire 		    prsuccess,
+		     input wire 		    enable,
+		     input wire [`SPECTAG_LEN-1:0]  tagregfix,
+		     output wire [`SPECTAG_LEN-1:0] sptag1,
+		     output wire [`SPECTAG_LEN-1:0] sptag2,
+		     output wire 		    speculative1,
+		     output wire 		    speculative2,
+		     output wire 		    attachable,
+		     output reg [`SPECTAG_LEN-1:0]  tagreg
+		     );
+
+//   reg [`SPECTAG_LEN-1:0] 		       tagreg;
+   reg [`BRDEPTH_LEN-1:0] 		       brdepth;
+   
+   assign sptag1 = (branchvalid1) ? 
+		   {tagreg[`SPECTAG_LEN-2:0], tagreg[`SPECTAG_LEN-1]}
+		   : tagreg;
+   assign sptag2 = (branchvalid2) ? 
+		   {sptag1[`SPECTAG_LEN-2:0], sptag1[`SPECTAG_LEN-1]}
+		   : sptag1;
+   assign speculative1 = (brdepth != 0) ? 1'b1 : 1'b0;
+   assign speculative2 = ((brdepth != 0) || branchvalid1) ? 1'b1 : 1'b0;
+   assign attachable = (brdepth + branchvalid1 + branchvalid2) 
+     > (`BRANCH_ENT_NUM + prsuccess) ? 1'b0 : 1'b1;
+
+   always @ (posedge clk) begin
+      if (reset) begin
+	 tagreg <= `SPECTAG_LEN'b1;
+	 brdepth <= `BRDEPTH_LEN'b0;
+      end else begin
+	 tagreg <= prmiss ? tagregfix :
+		   ~enable ? tagreg : 
+		   sptag2;
+	 brdepth <= prmiss ? `BRDEPTH_LEN'b0 :
+		    ~enable ? brdepth - prsuccess :
+		    brdepth + branchvalid1 + branchvalid2 - prsuccess;
+      end
+   end
+   
+endmodule // tag_generator
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/design/top.v
+++ b/examples/SQED_ridecore/rtl/design/top.v
@@ -1,0 +1,136 @@
+`include "define.v"
+`include "constants.vh"
+
+module top
+  (
+   input 	    CLK_P,
+   input 	    CLK_N,
+   input 	    RST_X_IN,
+   output 	    TXD,
+   input 	    RXD,
+   output reg [7:0] LED
+   );
+
+   //Active Low SW
+   wire 	    clk;
+   wire 	    reset_x;
+
+
+   wire [`ADDR_LEN-1:0] pc;
+   wire [4*`INSN_LEN-1:0] idata;
+   wire [8:0] 		  imem_addr;
+   wire [`DATA_LEN-1:0]   dmem_data;
+   wire [`DATA_LEN-1:0]   dmem_wdata;
+   wire [`ADDR_LEN-1:0]   dmem_addr;
+   wire 		  dmem_we;
+   wire [`DATA_LEN-1:0]   dmem_wdata_core;
+   wire [`ADDR_LEN-1:0]   dmem_addr_core;
+   wire 		  dmem_we_core;
+
+   wire 		  utx_we;
+   wire 		  finish_we;
+   reg 			  finished;
+   wire 		  ready_tx;
+   wire 		  loaded;
+   
+   reg 			  prog_loading;
+   wire [4*`INSN_LEN-1:0] prog_loaddata;
+   wire [`ADDR_LEN-1:0]   prog_loadaddr;
+   wire 		  prog_dmem_we;
+   wire 		  prog_imem_we;
+   
+   assign utx_we = (~finished && dmem_we_core && (dmem_addr_core == 32'h0)) ? 1'b1 : 1'b0;
+   assign finish_we = (dmem_we_core && (dmem_addr_core == 32'h8)) ? 1'b1 : 1'b0;
+   
+   always @ (posedge clk) begin
+      if (!reset_x) begin
+	 LED <= 0;
+      end else if (utx_we) begin
+	 LED <= {LED[7], dmem_wdata[6:0]};
+      end else if (finish_we) begin
+	 LED <= {1'b1, LED[6:0]};
+      end
+   end
+
+   always @ (posedge clk) begin
+      if (!reset_x) begin
+	 prog_loading <= 1'b1;
+      end else begin
+	 prog_loading <= ~loaded;
+      end
+   end
+
+   always @ (posedge clk) begin
+      if (!reset_x) begin
+	 finished <= 0;
+      end else if (finish_we) begin
+	 finished <= 1;
+      end
+   end
+   
+   GEN_MMCM_DS genmmcmds
+     (
+      .CLK_P(CLK_P), 
+      .CLK_N(CLK_N), 
+      .RST_X_I(~RST_X_IN), 
+      .CLK_O(clk), 
+      .RST_X_O(reset_x)
+      );
+
+   pipeline pipe
+     (
+      .clk(clk),
+      .reset(~reset_x | prog_loading),
+      .pc(pc),
+      .idata(idata),
+      .dmem_wdata(dmem_wdata_core),
+      .dmem_addr(dmem_addr_core),
+      .dmem_we(dmem_we_core),
+      .dmem_data(dmem_data)
+      );
+
+   assign dmem_addr = prog_loading ? prog_loadaddr : dmem_addr_core;
+   assign dmem_we = prog_loading ? prog_dmem_we : dmem_we_core;
+   assign dmem_wdata = prog_loading ? prog_loaddata[127:96] : dmem_wdata_core;
+   dmem datamemory(
+		   .clk(clk),
+		   .addr({2'b0, dmem_addr[`ADDR_LEN-1:2]}),
+		   .wdata(dmem_wdata),
+		   .we(dmem_we),
+		   .rdata(dmem_data)
+		   );
+
+   assign imem_addr = prog_loading ? prog_loadaddr[12:4] : pc[12:4];
+   imem_ld instmemory(
+		      .clk(~clk),
+		      .addr(imem_addr),
+		      .rdata(idata),
+		      .wdata(prog_loaddata),
+		      .we(prog_imem_we)
+		      );
+   
+   SingleUartTx sutx
+     (
+      .CLK(clk),
+      .RST_X(reset_x),
+      .TXD(TXD),
+      .ERR(),
+      .DT01(dmem_wdata[7:0]),
+      .WE01(utx_we)
+      );
+
+   PLOADER loader
+     (
+      .CLK(clk),
+      .RST_X(reset_x),
+      .RXD(RXD),
+      .ADDR(prog_loadaddr),
+      .DATA(prog_loaddata),
+      .WE_32(prog_dmem_we),
+      .WE_128(prog_imem_we),
+      .DONE(loaded)
+      );
+   
+endmodule // top
+
+   

--- a/examples/SQED_ridecore/rtl/design/top_ridecore.v
+++ b/examples/SQED_ridecore/rtl/design/top_ridecore.v
@@ -1,0 +1,218 @@
+`include "define.v"
+`include "constants.vh"
+
+module top_ridecore
+  (
+//   input 	    CLK_P,
+//   input 	    CLK_N,
+//   input 	    RST_X_IN,
+//   output 	    TXD,
+//   input 	    RXD,
+//   output reg [7:0] LED
+   input clk,
+   input reset_x,
+
+// EDIT
+   input [`INSN_LEN-1:0] qed_instruction,
+   input qed_vld_out,
+
+   output [`DATA_LEN-1:0] gpr0,
+   output [`DATA_LEN-1:0] gpr1,
+   output [`DATA_LEN-1:0] gpr2,
+   output [`DATA_LEN-1:0] gpr3,
+   output [`DATA_LEN-1:0] gpr4,
+   output [`DATA_LEN-1:0] gpr5,
+   output [`DATA_LEN-1:0] gpr6,
+   output [`DATA_LEN-1:0] gpr7,
+   output [`DATA_LEN-1:0] gpr8,
+   output [`DATA_LEN-1:0] gpr9,
+   output [`DATA_LEN-1:0] gpr10,
+   output [`DATA_LEN-1:0] gpr11,
+   output [`DATA_LEN-1:0] gpr12,
+   output [`DATA_LEN-1:0] gpr13,
+   output [`DATA_LEN-1:0] gpr14,
+   output [`DATA_LEN-1:0] gpr15,
+   output [`DATA_LEN-1:0] gpr16,
+   output [`DATA_LEN-1:0] gpr17,
+   output [`DATA_LEN-1:0] gpr18,
+   output [`DATA_LEN-1:0] gpr19,
+   output [`DATA_LEN-1:0] gpr20,
+   output [`DATA_LEN-1:0] gpr21,
+   output [`DATA_LEN-1:0] gpr22,
+   output [`DATA_LEN-1:0] gpr23,
+   output [`DATA_LEN-1:0] gpr24,
+   output [`DATA_LEN-1:0] gpr25,
+   output [`DATA_LEN-1:0] gpr26,
+   output [`DATA_LEN-1:0] gpr27,
+   output [`DATA_LEN-1:0] gpr28,
+   output [`DATA_LEN-1:0] gpr29,
+   output [`DATA_LEN-1:0] gpr30,
+   output [`DATA_LEN-1:0] gpr31,
+   output wire arfwe1,
+   output wire arfwe2,
+   output wire [`REG_SEL-1:0] dstarf1,
+   output wire [`REG_SEL-1:0] dstarf2,
+   output wire stall_IF
+// EDIT: END
+   );
+
+
+   //Active Low SW
+//   wire 	    clk;
+//   wire 	    reset_x;
+
+   (* keep *) wire [`ADDR_LEN-1:0] pc;
+   (* keep *) wire [4*`INSN_LEN-1:0] idata;
+   (* keep *) wire [8:0] 		  imem_addr;
+   (* keep *) wire [`DATA_LEN-1:0]   dmem_data;
+   (* keep *) wire [`DATA_LEN-1:0]   dmem_wdata;
+   (* keep *) wire [`ADDR_LEN-1:0]   dmem_addr;
+   (* keep *) wire 		  dmem_we;
+   (* keep *) wire [`DATA_LEN-1:0]   dmem_wdata_core;
+   (* keep *) wire [`ADDR_LEN-1:0]   dmem_addr_core;
+   (* keep *) wire 		  dmem_we_core;
+
+   wire 		  utx_we;
+   wire 		  finish_we;
+   wire 		  ready_tx;
+   wire 		  loaded;
+   
+   reg 			  prog_loading;
+   wire [4*`INSN_LEN-1:0] prog_loaddata = 0;
+   wire [`ADDR_LEN-1:0]   prog_loadaddr = 0;
+   wire 		  prog_dmem_we = 0;
+   wire 		  prog_imem_we = 0;
+
+/*   
+   assign utx_we = (dmem_we_core && (dmem_addr_core == 32'h0)) ? 1'b1 : 1'b0;
+   assign finish_we = (dmem_we_core && (dmem_addr_core == 32'h8)) ? 1'b1 : 1'b0;
+   
+   always @ (posedge clk) begin
+      if (!reset_x) begin
+	 LED <= 0;
+      end else if (utx_we) begin
+	 LED <= {LED[7], dmem_wdata[6:0]};
+      end else if (finish_we) begin
+	 LED <= {1'b1, LED[6:0]};
+      end
+   end
+*/
+   always @ (posedge clk) begin
+      if (!reset_x) begin
+	      prog_loading <= 1'b1;
+      end else begin
+	      prog_loading <= 0;
+      end
+   end
+/*   
+   GEN_MMCM_DS genmmcmds
+     (
+      .CLK_P(CLK_P), 
+      .CLK_N(CLK_N), 
+      .RST_X_I(~RST_X_IN), 
+      .CLK_O(clk), 
+      .RST_X_O(reset_x)
+      );
+*/
+   // EDIT: wire up the instruction to the new qed_instruction port
+   pipeline pipe
+     (
+      .qed_instruction(qed_instruction),
+      .qed_vld_out(qed_vld_out),
+      .clk(clk),
+      .reset(~reset_x),
+      .pc(pc),
+      .idata(idata),
+      .dmem_wdata(dmem_wdata_core),
+      .dmem_addr(dmem_addr_core),
+      .dmem_we(dmem_we_core),
+      .dmem_data(dmem_data),
+
+      .gpr0_o(gpr0),
+      .gpr1_o(gpr1),
+      .gpr2_o(gpr2),
+      .gpr3_o(gpr3),
+      .gpr4_o(gpr4),
+      .gpr5_o(gpr5),
+      .gpr6_o(gpr6),
+      .gpr7_o(gpr7),
+      .gpr8_o(gpr8),
+      .gpr9_o(gpr9),
+      .gpr10_o(gpr10),
+      .gpr11_o(gpr11),
+      .gpr12_o(gpr12),
+      .gpr13_o(gpr13),
+      .gpr14_o(gpr14),
+      .gpr15_o(gpr15),
+      .gpr16_o(gpr16),
+      .gpr17_o(gpr17),
+      .gpr18_o(gpr18),
+      .gpr19_o(gpr19),
+      .gpr20_o(gpr20),
+      .gpr21_o(gpr21),
+      .gpr22_o(gpr22),
+      .gpr23_o(gpr23),
+      .gpr24_o(gpr24),
+      .gpr25_o(gpr25),
+      .gpr26_o(gpr26),
+      .gpr27_o(gpr27),
+      .gpr28_o(gpr28),
+      .gpr29_o(gpr29),
+      .gpr30_o(gpr30),
+      .gpr31_o(gpr31),
+      .arfwe1_o(arfwe1),
+      .arfwe2_o(arfwe2),
+      .dstarf1_o(dstarf1),
+      .dstarf2_o(dstarf2),
+      .stall_IF_o(stall_IF)
+      // EDIT: END
+      );
+
+   assign dmem_addr = prog_loading ? prog_loadaddr : dmem_addr_core;
+   assign dmem_we = prog_loading ? prog_dmem_we : dmem_we_core;
+   assign dmem_wdata = prog_loading ? prog_loaddata[127:96] : dmem_wdata_core;
+   dmem datamemory(
+		   .clk(clk),
+		   .addr({2'b0, dmem_addr[`ADDR_LEN-1:2]}),
+		   .wdata(dmem_wdata),
+		   .we(dmem_we),
+		   .rdata(dmem_data)
+		   );
+
+   assign imem_addr = prog_loading ? prog_loadaddr[12:4] : pc[12:4];
+   imem_ld instmemory(
+            // EDIT: changed clk polarity
+		      //.clk(~clk),
+		      .clk(clk),
+            // EDIT: END
+            .addr(imem_addr),
+		      .rdata(idata),
+		      .wdata(prog_loaddata),
+		      .we(prog_imem_we)
+		      );
+/*   
+   SingleUartTx sutx
+     (
+      .CLK(clk),
+      .RST_X(reset_x),
+      .TXD(TXD),
+      .ERR(),
+      .DT01(dmem_wdata[7:0]),
+      .WE01(utx_we)
+      );
+
+   PLOADER loader
+     (
+      .CLK(clk),
+      .RST_X(reset_x),
+      .RXD(RXD),
+      .ADDR(prog_loadaddr),
+      .DATA(prog_loaddata),
+      .WE_32(prog_dmem_we),
+      .WE_128(prog_imem_we),
+      .DONE(loaded)
+      );
+*/   
+endmodule // top
+
+   

--- a/examples/SQED_ridecore/rtl/design/uart.v
+++ b/examples/SQED_ridecore/rtl/design/uart.v
@@ -1,0 +1,295 @@
+/**************************************************************************************************/
+/* Many-core processor project Arch Lab.                                               TOKYO TECH */
+/**************************************************************************************************/
+`default_nettype none
+  /**************************************************************************************************/
+`include "define.v"
+  /**************************************************************************************************/
+`define SS_SER_WAIT  'd0       // do not modify this. RS232C deserializer, State WAIT
+`define SS_SER_RCV0  'd1       // do not modify this. RS232C deserializer, State Receive0
+`define SS_SER_DONE  'd9       // do not modify this. RS232C deserializer, State DONE
+  /**************************************************************************************************/
+  /*
+   module UartTx(CLK, RST_X, DATA, WE, TXD, READY);
+   input  wire        CLK, RST_X, WE;
+   input  wire [15:0] DATA;
+   output reg         TXD, READY;
+
+   reg [18:0]   cmd;
+   reg [11:0]   waitnum;
+   reg [4:0]    cnt;
+
+   always @(posedge CLK or negedge RST_X) begin
+   if(~RST_X) begin
+   TXD       <= 1'b1;
+   READY     <= 1'b1;
+   cmd       <= 19'h7ffff;
+   waitnum   <= 0;
+   cnt       <= 0;
+        end else if( READY ) begin
+   TXD       <= 1'b1;
+   waitnum   <= 0;
+   if( WE )begin
+   READY <= 1'b0;
+   //cmd   <= {DATA[15:8], 2'b01, DATA[7:0], 1'b0};
+   cmd   <= {DATA[15:8], 2'b01, 8'b11111111, 1'b1};
+   cnt   <= 20;  // 10
+            end
+        end else if( waitnum >= `SERIAL_WCNT ) begin
+   TXD       <= cmd[0];
+   READY     <= (cnt == 1);
+   cmd       <= {1'b1, cmd[18:1]};
+   waitnum   <= 1;
+   cnt       <= cnt - 1;
+        end else begin
+   waitnum   <= waitnum + 1;
+        end
+    end
+   endmodule
+   */
+
+  module UartTx(CLK, RST_X, DATA, WE, TXD, READY);
+   input wire  CLK, RST_X, WE;
+   input wire [7:0] DATA;
+   output reg  TXD, READY;
+
+   reg [8:0]   cmd;
+   reg [11:0]  waitnum;
+   reg [3:0]   cnt;
+
+   always @(posedge CLK or negedge RST_X) begin
+      if(~RST_X) begin
+         TXD       <= 1'b1;
+         READY     <= 1'b1;
+         cmd       <= 9'h1ff;
+         waitnum   <= 0;
+         cnt       <= 0;
+      end else if( READY ) begin
+         TXD       <= 1'b1;
+         waitnum   <= 0;
+         if( WE )begin
+            READY <= 1'b0;
+            cmd   <= {DATA, 1'b0};
+            cnt   <= 10;
+         end
+      end else if( waitnum >= `SERIAL_WCNT ) begin
+         TXD       <= cmd[0];
+         READY     <= (cnt == 1);
+         cmd       <= {1'b1, cmd[8:1]};
+         waitnum   <= 1;
+         cnt       <= cnt - 1;
+      end else begin
+         waitnum   <= waitnum + 1;
+      end
+   end
+endmodule
+
+/**************************************************************************************************/
+
+module TX_FIFO(CLK, RST_X, D_IN, WE, RE, D_OUT, D_EN, RDY, ERR);
+   input  wire       CLK, RST_X, WE, RE;
+   input  wire [7:0] D_IN;
+   output reg [7:0]  D_OUT;
+   output reg        D_EN, ERR;
+   output wire       RDY;
+   
+   reg [7:0] 	     mem [0:2048-1]; // FIFO memory
+   reg [10:0] 	     head, tail;    // regs for FIFO 
+   
+   assign RDY = (D_EN==0 && head!=tail);
+   
+   always @(posedge CLK) begin
+      if(~RST_X) begin 
+         {D_EN, ERR, head, tail, D_OUT} <= 0;
+      end
+      else begin            
+         if(WE) begin  ///// enqueue
+            mem[tail] <= D_IN;
+            tail <= tail + 1;
+            if(head == (tail + 1)) ERR <= 1; // buffer may full!
+         end
+         
+         if(RE) begin  ///// dequeue   
+            D_OUT <= mem[head];
+            D_EN  <= 1;
+            head <= head + 1;
+         end else begin
+            D_EN <= 0;
+         end
+      end
+   end
+endmodule
+
+/**************************************************************************************************/
+/*
+ module MultiUartTx(CLK, RST_X, TXD, ERR, 
+ DT01, WE01, DT02, WE02, DT03, WE03, DT04, WE04);
+ input  wire       CLK, RST_X;
+ input  wire [7:0] DT01, DT02, DT03, DT04;
+ input  wire       WE01, WE02, WE03, WE04;
+ output wire       TXD, ERR;
+ 
+ wire RE01, RE02, RE03, RE04;
+ wire [7:0] data01, data02, data03, data04;
+ wire en01, en02, en03, en04;
+ wire RDY01, RDY02, RDY03, RDY04;
+ wire ERR01, ERR02, ERR03, ERR04;
+ wire [15:0] data;
+ wire en;
+ wire TxRdy;
+
+ assign ERR = ERR01 | ERR02 | ERR03 | ERR04;
+ assign RE01 = (RDY01 & TxRdy);
+ assign RE02 = (RDY02 & TxRdy) & (~RDY01 & ~en01);
+ assign RE03 = (RDY03 & TxRdy) & (~RDY01 & ~en01) & (~RDY02 & ~en02);
+ assign RE04 = (RDY04 & TxRdy) & (~RDY01 & ~en01) & (~RDY02 & ~en02) & (~RDY03 & ~en03);
+ 
+ assign data = (en01) ? {data01, 8'h30} : 
+ (en02) ? {data02, 8'h31} :
+ (en03) ? {data03, 8'h32} : {data04, 8'h33};
+ assign en = en01 | en02 | en03 | en04;
+
+ TX_FIFO fifo_01(CLK, RST_X, DT01, WE01, RE01, data01, en01, RDY01, ERR01); 
+ TX_FIFO fifo_02(CLK, RST_X, DT02, WE02, RE02, data02, en02, RDY02, ERR02); 
+ TX_FIFO fifo_03(CLK, RST_X, DT03, WE03, RE03, data03, en03, RDY03, ERR03); 
+ TX_FIFO fifo_04(CLK, RST_X, DT04, WE04, RE04, data04, en04, RDY04, ERR04); 
+ UartTx send(CLK, RST_X, data, en, TXD, TxRdy);
+ endmodule
+ */
+module SingleUartTx(CLK, RST_X, TXD, ERR, DT01, WE01);
+   input  wire       CLK, RST_X;
+   input  wire [7:0] DT01;
+   input  wire 	     WE01;
+   output wire 	     TXD, ERR;
+   
+   wire 	     RE01;
+   wire [7:0] 	     data01;
+   wire 	     en01;
+   wire 	     RDY01;
+   wire 	     ERR01;
+   wire 	     TxRdy;
+
+   assign ERR = ERR01;
+   assign RE01 = (RDY01 & TxRdy);
+
+   TX_FIFO fifo_01(CLK, RST_X, DT01, WE01, RE01, data01, en01, RDY01, ERR01); 
+   UartTx send(CLK, RST_X, data01, en01, TXD, TxRdy);
+endmodule
+
+
+/**************************************************************************************************/
+
+module UartRx(CLK, RST_X, RXD, DATA, EN);
+   input  wire       CLK, RST_X, RXD; // clock, reset, RS232C input
+   output reg [7:0]  DATA;            // 8bit output data
+   output reg        EN;              // 8bit output data enable
+
+   reg [3:0] 	     stage;
+   reg [12:0] 	     cnt;             // counter to latch D0, D1, ..., D7
+   reg [11:0] 	     cnt_start;       // counter to detect the Start Bit
+   wire [12:0] 	     waitcnt;
+
+   assign waitcnt = `SERIAL_WCNT;
+
+   always @(posedge CLK or negedge RST_X)
+     if (~RST_X) cnt_start <= 0;
+     else        cnt_start <= (RXD) ? 0 : cnt_start + 1;
+
+   always @(posedge CLK or negedge RST_X)
+     if(~RST_X) begin
+        EN     <= 0;
+        stage  <= `SS_SER_WAIT;
+        cnt    <= 1;
+        DATA   <= 0;
+     end else if (stage == `SS_SER_WAIT) begin // detect the Start Bit
+        EN <= 0;
+        stage <= (cnt_start == (waitcnt >> 1)) ? `SS_SER_RCV0 : stage;
+     end else begin
+        if (cnt != waitcnt) begin
+           cnt <= cnt + 1;
+           EN <= 0;
+        end else begin // receive 1bit data
+           stage  <= (stage == `SS_SER_DONE) ? `SS_SER_WAIT : stage + 1;
+           EN     <= (stage == 8)  ? 1 : 0;
+           DATA   <= {RXD, DATA[7:1]};
+           cnt <= 1;
+        end
+     end
+endmodule
+
+/**************************************************************************************************/
+/*
+module PLOADER(CLK, RST_X, RXD, ADDR, DATA, WE, DONE1, DONE2);
+   input  wire       CLK, RST_X, RXD;
+   output reg [31:0] ADDR;
+   output reg [31:0] DATA;
+   output reg        WE;
+   output reg        DONE1; // application program load is done
+   output reg        DONE2; // scheduling program load is done
+
+   reg [31:0] 	     waddr; // memory write address
+
+   wire 	     SER_EN;
+   wire [7:0] 	     SER_DATA;
+   
+   UartRx recv(CLK, RST_X, RXD, SER_DATA, SER_EN);
+
+   always @(posedge CLK or negedge RST_X) begin
+      if(~RST_X) begin
+         {ADDR, DATA, WE, waddr, DONE1, DONE2} <= 0;
+      end else begin
+         if(DONE2==0 && SER_EN) begin
+            //ADDR  <= (waddr<32'h40000) ? waddr : {8'h04, 6'd0, waddr[17:0]};
+            ADDR  <= waddr;            
+            DATA  <= {SER_DATA, DATA[31:8]};
+            WE    <= (waddr[1:0]==3);
+            waddr <= waddr + 1;
+            if(waddr>=`APP_SIZE) DONE1 <= 1;
+         end else begin
+            WE <= 0;
+            if(waddr>=`APP_SIZE) DONE1 <= 1;
+            if(waddr>=`IMG_SIZE) DONE2 <= 1;
+         end
+      end
+   end
+endmodule
+*/
+
+module PLOADER(CLK, RST_X, RXD, ADDR, DATA, WE_32, WE_128, DONE);
+   input  wire       CLK, RST_X, RXD;
+   output reg [31:0] ADDR;
+   output reg [127:0] DATA;
+   output reg        WE_32;
+   output reg 	     WE_128;
+   output reg        DONE;
+
+   reg [31:0] 	     waddr; // memory write address
+
+   wire 	     SER_EN;
+   wire [7:0] 	     SER_DATA;
+   
+   UartRx recv(CLK, RST_X, RXD, SER_DATA, SER_EN);
+
+   always @(posedge CLK or negedge RST_X) begin
+      if(~RST_X) begin
+         {ADDR, DATA, WE_32, WE_128, waddr, DONE} <= 0;
+      end else begin
+         if(DONE==0 && SER_EN) begin
+            ADDR   <= waddr;            
+            DATA   <= {SER_DATA, DATA[127:8]};
+            WE_32  <= (waddr[1:0]==3) ? 1'b1 : 1'b0;
+	    WE_128 <= (waddr[3:0]==15) ? 1'b1 : 1'b0;
+            waddr <= waddr + 1;
+            if(waddr>=`APP_SIZE) DONE <= 1;
+         end else begin
+            WE_32 <= 0;
+	    WE_128 <= 0;
+            if(waddr>=`APP_SIZE) DONE <= 1;
+         end
+      end
+   end
+endmodule
+
+/**************************************************************************************************/
+`default_nettype wire
+  /**************************************************************************************************/

--- a/examples/SQED_ridecore/rtl/qed_files/inst_constraints.v
+++ b/examples/SQED_ridecore/rtl/qed_files/inst_constraints.v
@@ -1,0 +1,123 @@
+// Copyright (c) Stanford University
+//
+// This source code is patent protected and being made available under the
+// terms explained in the ../LICENSE-Academic and ../LICENSE-GOV files.
+//
+// Author: Mario J Srouji
+// Email: msrouji@stanford.edu
+
+module inst_constraints (clk,
+                        instruction);
+    
+    input clk;
+    input [31:0] instruction;
+    
+    wire [6:0] funct7;
+    wire [2:0] funct3;
+    wire [4:0] rd;
+    wire [4:0] rs1;
+    wire [4:0] rs2;
+    wire [6:0] opcode;
+    wire [4:0] shamt;
+    wire [11:0] imm12;
+    wire [6:0] imm7;
+    wire [4:0] imm5;
+    
+    wire FORMAT_R;
+    wire ALLOWED_R;
+    wire ADD;
+    wire SUB;
+    wire SLL;
+    wire SLT;
+    wire SLTU;
+    wire XOR;
+    wire SRL;
+    wire SRA;
+    wire OR;
+    wire AND;
+    wire MUL;
+    wire MULH;
+    wire MULHSU;
+    wire MULHU;
+    
+    wire FORMAT_I;
+    wire ALLOWED_I;
+    wire ADDI;
+    wire SLTI;
+    wire SLTIU;
+    wire XORI;
+    wire ORI;
+    wire ANDI;
+    wire SLLI;
+    wire SRLI;
+    wire SRAI;
+    
+    wire FORMAT_LW;
+    wire ALLOWED_LW;
+    wire LW;
+    
+    wire FORMAT_SW;
+    wire ALLOWED_SW;
+    wire SW;
+    
+    wire ALLOWED_NOP;
+    wire NOP;
+    
+    assign funct7 = instruction[31:25];
+    assign funct3 = instruction[14:12];
+    assign rd     = instruction[11:7];
+    assign rs1    = instruction[19:15];
+    assign rs2    = instruction[24:20];
+    assign opcode = instruction[6:0];
+    assign shamt  = instruction[24:20];
+    assign imm12  = instruction[31:20];
+    assign imm7   = instruction[31:25];
+    assign imm5   = instruction[11:7];
+    
+    assign FORMAT_R  = (rs2 < 16) && (rs1 < 16) && (rd < 16);
+    assign ADD       = FORMAT_R && (funct3 == 3'b000) && (funct7 == 7'b0000000) && (opcode == 7'b0110011);
+    assign SUB       = FORMAT_R && (funct3 == 3'b000) && (funct7 == 7'b0100000) && (opcode == 7'b0110011);
+    assign SLL       = FORMAT_R && (funct3 == 3'b001) && (funct7 == 7'b0000000) && (opcode == 7'b0110011);
+    assign SLT       = FORMAT_R && (funct3 == 3'b010) && (funct7 == 7'b0000000) && (opcode == 7'b0110011);
+    assign SLTU      = FORMAT_R && (funct3 == 3'b011) && (funct7 == 7'b0000000) && (opcode == 7'b0110011);
+    assign XOR       = FORMAT_R && (funct3 == 3'b100) && (funct7 == 7'b0000000) && (opcode == 7'b0110011);
+    assign SRL       = FORMAT_R && (funct3 == 3'b101) && (funct7 == 7'b0000000) && (opcode == 7'b0110011);
+    assign SRA       = FORMAT_R && (funct3 == 3'b101) && (funct7 == 7'b0100000) && (opcode == 7'b0110011);
+    assign OR        = FORMAT_R && (funct3 == 3'b110) && (funct7 == 7'b0000000) && (opcode == 7'b0110011);
+    assign AND       = FORMAT_R && (funct3 == 3'b111) && (funct7 == 7'b0000000) && (opcode == 7'b0110011);
+    assign MUL       = FORMAT_R && (funct3 == 3'b000) && (funct7 == 7'b0000001) && (opcode == 7'b0110011);
+    assign MULH      = FORMAT_R && (funct3 == 3'b001) && (funct7 == 7'b0000001) && (opcode == 7'b0110011);
+    assign MULHSU    = FORMAT_R && (funct3 == 3'b010) && (funct7 == 7'b0000001) && (opcode == 7'b0110011);
+    assign MULHU     = FORMAT_R && (funct3 == 3'b011) && (funct7 == 7'b0000001) && (opcode == 7'b0110011);
+    assign ALLOWED_R = ADD || SUB || SLL || SLT || SLTU || XOR || SRL || SRA || OR || AND || MUL || MULH || MULHSU || MULHU;
+    
+    assign FORMAT_I  = (rs1 < 16) && (rd < 16);
+    assign ADDI      = FORMAT_I && (funct3 == 3'b000) && (opcode == 7'b0010011);
+    assign SLTI      = FORMAT_I && (funct3 == 3'b010) && (opcode == 7'b0010011);
+    assign SLTIU     = FORMAT_I && (funct3 == 3'b011) && (opcode == 7'b0010011);
+    assign XORI      = FORMAT_I && (funct3 == 3'b100) && (opcode == 7'b0010011);
+    assign ORI       = FORMAT_I && (funct3 == 3'b110) && (opcode == 7'b0010011);
+    assign ANDI      = FORMAT_I && (funct3 == 3'b111) && (opcode == 7'b0010011);
+    assign SLLI      = FORMAT_I && (funct3 == 3'b001) && (funct7 == 7'b0000000) && (opcode == 7'b0010011);
+    assign SRLI      = FORMAT_I && (funct3 == 3'b101) && (funct7 == 7'b0000000) && (opcode == 7'b0010011);
+    assign SRAI      = FORMAT_I && (funct3 == 3'b101) && (funct7 == 7'b0100000) && (opcode == 7'b0010011);
+    assign ALLOWED_I = ADDI || SLTI || SLTIU || XORI || ORI || ANDI || SLLI || SRLI || SRAI;
+    
+    assign FORMAT_LW  = (instruction[31:30] == 00) && (rs1 < 16) && (rd < 16);
+    assign LW         = FORMAT_LW && (rs1 == 5'b00000) && (opcode == 7'b0000011) && (funct3 == 3'b010);
+    assign ALLOWED_LW = LW;
+    
+    assign FORMAT_SW  = (instruction[31:30] == 00) && (rs2 < 16) && (rs1 < 16);
+    assign SW         = FORMAT_SW && (rs1 == 5'b00000) && (opcode == 7'b0100011) && (funct3 == 3'b010);
+    assign ALLOWED_SW = SW;
+    
+    assign NOP         = (opcode == 7'b1111111);
+    assign ALLOWED_NOP = NOP;
+    
+    `ifndef VERILATOR
+    always @(posedge clk) begin
+        assume (ALLOWED_R || ALLOWED_I || ALLOWED_LW || ALLOWED_SW || ALLOWED_NOP);
+    end
+    `endif
+    
+endmodule

--- a/examples/SQED_ridecore/rtl/qed_files/modify_instruction.v
+++ b/examples/SQED_ridecore/rtl/qed_files/modify_instruction.v
@@ -1,0 +1,72 @@
+// Copyright (c) Stanford University
+// 
+// This source code is patent protected and being made available under the
+// terms explained in the ../LICENSE-Academic and ../LICENSE-GOV files.
+//
+// Author: Mario J Srouji
+// Email: msrouji@stanford.edu
+
+module modify_instruction (
+// Outputs
+qed_instruction,
+// Inputs
+qic_qimux_instruction,
+funct7,
+funct3,
+rd,
+rs1,
+rs2,
+opcode,
+shamt,
+imm12,
+imm7,
+imm5,
+IS_R,
+IS_I,
+IS_LW,
+IS_SW);
+
+  input [31:0] qic_qimux_instruction;
+  input [6:0] funct7;
+  input [2:0] funct3;
+  input [4:0] rd;
+  input [4:0] rs1;
+  input [4:0] rs2;
+  input [6:0] opcode;
+  input [4:0] shamt;
+  input [11:0] imm12;
+  input [6:0] imm7;
+  input [4:0] imm5;
+  input IS_R;
+  input IS_I;
+  input IS_LW;
+  input IS_SW;
+
+  output reg [31:0] qed_instruction;
+
+  wire [31:0] INS_R;
+  wire [31:0] INS_I;
+  wire [31:0] INS_LW;
+  wire [31:0] INS_SW;
+  wire [31:0] INS_CONSTRAINT;
+
+  wire [4:0] NEW_rd;
+  wire [4:0] NEW_rs1;
+  wire [4:0] NEW_rs2;
+  wire [11:0] NEW_imm12;
+  wire [6:0] NEW_imm7;
+
+  assign NEW_rd = (rd == 5'b00000) ? rd : {1'b1, rd[3:0]};
+  assign NEW_rs1 = (rs1 == 5'b00000) ? rs1 : {1'b1, rs1[3:0]};
+  assign NEW_rs2 = (rs2 == 5'b00000) ? rs2 : {1'b1, rs2[3:0]};
+  assign NEW_imm12 = {2'b01, imm12[9:0]};
+  assign NEW_imm7 = {2'b01, imm7[4:0]};
+
+  assign INS_R = {funct7, NEW_rs2, NEW_rs1, funct3, NEW_rd, opcode};
+  assign INS_I = {imm12, NEW_rs1, funct3, NEW_rd, opcode};
+  assign INS_LW = {NEW_imm12, NEW_rs1, funct3, NEW_rd, opcode};
+  assign INS_SW = {NEW_imm7, NEW_rs2, NEW_rs1, funct3, imm5, opcode};
+
+  assign qed_instruction = IS_R ? INS_R : (IS_I ? INS_I : (IS_LW ? INS_LW : (IS_SW ? INS_SW : qic_qimux_instruction)));
+
+endmodule

--- a/examples/SQED_ridecore/rtl/qed_files/properties.v
+++ b/examples/SQED_ridecore/rtl/qed_files/properties.v
@@ -1,0 +1,123 @@
+module properties #(
+    parameter REG_SEL = 5,
+    parameter DATA_LEN = 32
+)
+(
+    input clk,
+    input rst,
+    input [DATA_LEN-1:0] reg_val0,
+    input [DATA_LEN-1:0] reg_val1,
+    input [DATA_LEN-1:0] reg_val2,
+    input [DATA_LEN-1:0] reg_val3,
+    input [DATA_LEN-1:0] reg_val4,
+    input [DATA_LEN-1:0] reg_val5,
+    input [DATA_LEN-1:0] reg_val6,
+    input [DATA_LEN-1:0] reg_val7,
+    input [DATA_LEN-1:0] reg_val8,
+    input [DATA_LEN-1:0] reg_val9,
+    input [DATA_LEN-1:0] reg_val10,
+    input [DATA_LEN-1:0] reg_val11,
+    input [DATA_LEN-1:0] reg_val12,
+    input [DATA_LEN-1:0] reg_val13,
+    input [DATA_LEN-1:0] reg_val14,
+    input [DATA_LEN-1:0] reg_val15,
+    input [DATA_LEN-1:0] reg_val16,
+    input [DATA_LEN-1:0] reg_val17,
+    input [DATA_LEN-1:0] reg_val18,
+    input [DATA_LEN-1:0] reg_val19,
+    input [DATA_LEN-1:0] reg_val20,
+    input [DATA_LEN-1:0] reg_val21,
+    input [DATA_LEN-1:0] reg_val22,
+    input [DATA_LEN-1:0] reg_val23,
+    input [DATA_LEN-1:0] reg_val24,
+    input [DATA_LEN-1:0] reg_val25,
+    input [DATA_LEN-1:0] reg_val26,
+    input [DATA_LEN-1:0] reg_val27,
+    input [DATA_LEN-1:0] reg_val28,
+    input [DATA_LEN-1:0] reg_val29,
+    input [DATA_LEN-1:0] reg_val30,
+    input [DATA_LEN-1:0] reg_val31,
+    input arfwe1,
+    input arfwe2,
+    input [REG_SEL-1:0] dstarf1,
+    input [REG_SEL-1:0] dstarf2
+);
+
+   // embed the assumption that there's no reset into the generated BTOR2
+   // we will run the reset sequence in Yosys before generating the BTOR2
+   // it will complain about the violated assumption, but should work
+   // fine otherwise
+   // this is a pos-edge reset, so we assume it is 0.
+    always @* begin
+        no_reset: assume(rst == 1'b0);
+    end
+
+    // Insert the ready logic: tracks number of committed instructions 
+    (* keep *) wire qed_ready;
+    (* keep *) reg [15:0] num_orig_insts;
+    (* keep *) reg [15:0] num_dup_insts;
+    (* keep *) integer timecount; 
+    (* keep *) wire timeout; //if timeout, force to quit
+    wire [1:0] num_orig_commits;
+    wire [1:0] num_dup_commits;
+
+    // Instruction with destination register as 5'b0 is a NOP so ignore those
+   assign num_orig_commits = ((arfwe1 == 1)&&(dstarf1 < 16)&&(dstarf1 != 5'b0)
+			      &&(arfwe2 == 1)&&(dstarf2 < 16)&&(dstarf2 != 5'b0)) ? 2'b10 :
+			     ((((arfwe1 == 1)&&(dstarf1 < 16)&&(dstarf1 != 5'b0)
+			       &&((arfwe2 != 1)||(dstarf2 >= 16)||(dstarf2 == 5'b0)))
+			      ||((arfwe2 == 1)&&(dstarf2 < 16)&&(dstarf2 != 5'b0)
+				 &&((arfwe1 != 1)||(dstarf1 >= 16)||(dstarf1 == 5'b0)))) ? 2'b01 : 2'b00) ;
+
+
+   // When destination register is 5'b0, it remains the same for both original and duplicate
+   assign num_dup_commits = ((arfwe1 == 1)&&(dstarf1 >= 16)
+			      &&(arfwe2 == 1)&&(dstarf2 >= 16)) ? 2'b10 :
+			     ((((arfwe1 == 1)&&(dstarf1 >= 16)
+			       &&((arfwe2 != 1)||(dstarf2 < 16)))
+			      ||((arfwe2 == 1)&&(dstarf2 >= 16)
+				 &&((arfwe1 != 1)||(dstarf1 < 16)))) ? 2'b01 : 2'b00) ;
+
+    always @(posedge clk) begin
+		if (rst) begin
+	   		num_orig_insts <= 16'b0;
+	   		num_dup_insts <= 16'b0;
+		end else begin
+	   		num_orig_insts <= num_orig_insts + {14'b0,num_orig_commits};
+	   		num_dup_insts <= num_dup_insts + {14'b0,num_dup_commits};
+		end
+    end
+
+    always @(posedge clk) begin
+        if(rst) begin
+            timecount <= 0;
+        end 
+        else begin
+            timecount <= timecount + 1;
+        end
+    end
+
+    assign timeout = (timecount >= 12);
+    //assign qed_ready = timeout; // For debug
+    assign qed_ready = (num_orig_insts == num_dup_insts);
+
+    always @(posedge clk) begin
+        if (qed_ready) begin
+            qed_consistency: assert property ( (reg_val0 == 0) &&
+                                 (reg_val1 == reg_val17) && (reg_val2 == reg_val18) &&
+	                             (reg_val3 == reg_val19) && (reg_val4 == reg_val20) &&
+							     (reg_val5 == reg_val21) && (reg_val6 == reg_val22) &&
+							     (reg_val7 == reg_val23) && (reg_val8 == reg_val24) &&
+							     (reg_val9 == reg_val25) && (reg_val10 == reg_val26) &&
+							     (reg_val11 == reg_val27) && (reg_val12 == reg_val28) &&
+                                 (reg_val13 == reg_val29) && (reg_val14 == reg_val30) &&
+                                 (reg_val15 == reg_val31) 
+	   		                 );
+            
+	    end
+    end
+
+    
+endmodule
+
+`default_nettype wire

--- a/examples/SQED_ridecore/rtl/qed_files/qed.v
+++ b/examples/SQED_ridecore/rtl/qed_files/qed.v
@@ -1,0 +1,96 @@
+// Copyright (c) Stanford University
+// 
+// This source code is patent protected and being made available under the
+// terms explained in the ../LICENSE-Academic and ../LICENSE-GOV files.
+//
+// Author: Mario J Srouji
+// Email: msrouji@stanford.edu
+
+module qed (
+// Outputs
+qed_ifu_instruction,
+vld_out,
+// Inputs
+clk,
+ifu_qed_instruction,
+rst,
+ena,
+exec_dup,
+stall_IF);
+
+  input clk;
+  input rst;
+  input ena;
+  input exec_dup;
+  input [31:0] ifu_qed_instruction;
+  input stall_IF;
+
+  output [31:0] qed_ifu_instruction;
+  output vld_out;
+  wire [6:0] funct7;
+  wire [2:0] funct3;
+  wire [4:0] rd;
+  wire [4:0] rs1;
+  wire [4:0] rs2;
+  wire [6:0] opcode;
+  wire [4:0] shamt;
+  wire [11:0] imm12;
+  wire [6:0] imm7;
+  wire [4:0] imm5;
+
+  wire IS_R;
+  wire IS_I;
+  wire IS_LW;
+  wire IS_SW;
+
+  wire [31:0] qed_instruction;
+  wire [31:0] qic_qimux_instruction;
+
+  qed_decoder dec (.ifu_qed_instruction(qic_qimux_instruction),
+                   .funct7(funct7),
+                   .funct3(funct3),
+                   .rd(rd),
+                   .rs1(rs1),
+                   .rs2(rs2),
+                   .opcode(opcode),
+                   .shamt(shamt),
+                   .imm12(imm12),
+                   .imm7(imm7),
+                   .imm5(imm5),
+                   .IS_R(IS_R),
+                   .IS_I(IS_I),
+                   .IS_LW(IS_LW),
+                   .IS_SW(IS_SW));
+
+  modify_instruction minst (.qed_instruction(qed_instruction),
+                            .qic_qimux_instruction(qic_qimux_instruction),
+                            .funct7(funct7),
+                            .funct3(funct3),
+                            .rd(rd),
+                            .rs1(rs1),
+                            .rs2(rs2),
+                            .opcode(opcode),
+                            .shamt(shamt),
+                            .imm12(imm12),
+                            .imm7(imm7),
+                            .imm5(imm5),
+                            .IS_R(IS_R),
+                            .IS_I(IS_I),
+                            .IS_LW(IS_LW),
+                            .IS_SW(IS_SW));
+
+  qed_instruction_mux imux (.qed_ifu_instruction(qed_ifu_instruction),
+                            .ifu_qed_instruction(ifu_qed_instruction),
+                            .qed_instruction(qed_instruction),
+                            .exec_dup(exec_dup),
+                            .ena(ena));
+
+  qed_i_cache qic (.qic_qimux_instruction(qic_qimux_instruction),
+                   .vld_out(vld_out),
+                   .clk(clk),
+                   .rst(rst),
+                   .exec_dup(exec_dup),
+                   .IF_stall(stall_IF),
+                   .ifu_qed_instruction(ifu_qed_instruction));
+
+endmodule

--- a/examples/SQED_ridecore/rtl/qed_files/qed_decoder.v
+++ b/examples/SQED_ridecore/rtl/qed_files/qed_decoder.v
@@ -1,0 +1,61 @@
+// Copyright (c) Stanford University
+// 
+// This source code is patent protected and being made available under the
+// terms explained in the ../LICENSE-Academic and ../LICENSE-GOV files.
+//
+// Author: Mario J Srouji
+// Email: msrouji@stanford.edu
+
+module qed_decoder (
+// Outputs
+funct7,
+funct3,
+rd,
+rs1,
+rs2,
+opcode,
+shamt,
+imm12,
+imm7,
+imm5,
+IS_R,
+IS_I,
+IS_LW,
+IS_SW,
+// Inputs
+ifu_qed_instruction);
+
+  input [31:0] ifu_qed_instruction;
+
+  output [6:0] funct7;
+  output [2:0] funct3;
+  output [4:0] rd;
+  output [4:0] rs1;
+  output [4:0] rs2;
+  output [6:0] opcode;
+  output [4:0] shamt;
+  output [11:0] imm12;
+  output [6:0] imm7;
+  output [4:0] imm5;
+  output IS_R;
+  output IS_I;
+  output IS_LW;
+  output IS_SW;
+
+  assign funct7 = ifu_qed_instruction[31:25];
+  assign funct3 = ifu_qed_instruction[14:12];
+  assign rd = ifu_qed_instruction[11:7];
+  assign rs1 = ifu_qed_instruction[19:15];
+  assign rs2 = ifu_qed_instruction[24:20];
+  assign opcode = ifu_qed_instruction[6:0];
+  assign shamt = ifu_qed_instruction[24:20];
+  assign imm12 = ifu_qed_instruction[31:20];
+  assign imm7 = ifu_qed_instruction[31:25];
+  assign imm5 = ifu_qed_instruction[11:7];
+
+  assign IS_R = (opcode == 7'b0110011);
+  assign IS_I = (opcode == 7'b0010011);
+  assign IS_LW = (opcode == 7'b0000011) && (funct3 == 3'b010);
+  assign IS_SW = (opcode == 7'b0100011) && (funct3 == 3'b010);
+
+endmodule

--- a/examples/SQED_ridecore/rtl/qed_files/qed_i_cache.v
+++ b/examples/SQED_ridecore/rtl/qed_files/qed_i_cache.v
@@ -1,0 +1,69 @@
+// Copyright (c) Stanford University
+//
+// This source code is patent protected and being made available under the
+// terms explained in the ../LICENSE-Academic and ../LICENSE-GOV files.
+
+module qed_i_cache (
+  // Outputs
+  qic_qimux_instruction,
+  vld_out,  
+  // Inputs
+  clk, 
+  rst,
+  exec_dup, 
+  IF_stall,
+  ifu_qed_instruction
+  );
+
+  parameter ICACHESIZE = 256;
+
+  input clk;
+  input rst;
+  input exec_dup;
+  input IF_stall;
+  input [31:0] ifu_qed_instruction;
+
+  output vld_out;
+  output [31:0] qic_qimux_instruction;
+
+  reg [31:0] i_cache[ICACHESIZE-1:0];
+  reg [6:0] address_tail;  
+  reg [6:0] address_head;
+
+  wire is_empty;
+  wire is_full;
+  wire is_nop;
+  wire insert_cond ;
+  wire delete_cond;
+  wire [31:0] instruction;
+
+  assign insert_cond = (~rst) & (~exec_dup) & (~is_nop) & (~IF_stall) & (~is_full);
+  assign delete_cond = (~rst) & (exec_dup) & (~is_empty) & (~IF_stall);
+  assign is_nop = (ifu_qed_instruction[6:0] == 7'b1111111);
+  assign is_empty = (address_tail == address_head);
+  assign is_full = ((address_tail + 1) == address_head);
+  assign vld_out = (~insert_cond & ~delete_cond) ? 1'b0 : 1'b1;
+
+  always @(posedge clk) begin
+    if (rst) begin
+      address_tail <= 7'b0;
+	  address_head <= 7'b0;
+    end 
+    else if (insert_cond) begin
+	  i_cache[address_tail] <= ifu_qed_instruction;
+      address_tail <= address_tail + 1;
+    end 
+    else if (delete_cond) begin
+	  address_head <= address_head + 1;
+	end
+  end
+
+  assign instruction = i_cache[address_head];
+  assign qic_qimux_instruction = insert_cond ? ifu_qed_instruction : (delete_cond ? instruction : 32'b1111111);
+
+endmodule 
+
+
+
+
+

--- a/examples/SQED_ridecore/rtl/qed_files/qed_instruction_mux.v
+++ b/examples/SQED_ridecore/rtl/qed_files/qed_instruction_mux.v
@@ -1,0 +1,26 @@
+// Copyright (c) Stanford University
+//
+// This source code is patent protected and being made available under the
+// terms explained in the ../LICENSE-Academic and ../LICENSE-GOV files.
+
+module qed_instruction_mux (
+  // Outputs
+  qed_ifu_instruction,
+  // Inputs
+  ifu_qed_instruction, 
+  qed_instruction, 
+  ena, 
+  exec_dup
+  );
+
+  input [31:0] ifu_qed_instruction;
+  input [31:0] qed_instruction;
+  input exec_dup;
+  input ena;
+
+  output [31:0] qed_ifu_instruction;
+
+  assign qed_ifu_instruction = ena ? ((exec_dup == 1'b0) ? ifu_qed_instruction : qed_instruction) : ifu_qed_instruction;
+
+endmodule 
+

--- a/examples/SQED_ridecore/test_eq.sby
+++ b/examples/SQED_ridecore/test_eq.sby
@@ -1,0 +1,40 @@
+[options]
+mode bmc
+depth 12
+timeout 7200
+expect pass,fail,timeout
+
+
+[engines]
+btor pono
+
+
+[script]
+read_verilog -sv test_eq.sv inst_constraints.v modify_instruction.v qed_decoder.v qed_i_cache.v qed_instruction_mux.v qed.v
+#read_ilang mutated.il
+read_rtlil mutated.il
+#clk2fflogic
+async2sync
+chformal -lower
+chformal -assume -early
+prep -top miter
+hierarchy -check 
+proc
+flatten
+memory 
+opt -fast
+#fmcombine miter ref uut
+dffunmap
+sim -clock din_clk -resetn din_rst_n -n 5 -rstlen 5 -zinit -w miter
+setundef -undriven -expose
+
+
+[files]
+../../test_eq.sv 
+../../rtl/qed_files/inst_constraints.v 
+../../rtl/qed_files/modify_instruction.v 
+../../rtl/qed_files/qed_decoder.v 
+../../rtl/qed_files/qed_i_cache.v 
+../../rtl/qed_files/qed_instruction_mux.v
+../../rtl/qed_files/qed.v 
+mutated.il

--- a/examples/SQED_ridecore/test_eq.sh
+++ b/examples/SQED_ridecore/test_eq.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+exec 2>&1
+set -ex
+
+SCRIPTS=/mnt/data/liyf/Computer-Architecture/model_checking/oss-cad-suite/share/mcy/scripts
+
+bash $SCRIPTS/create_mutated.sh -c -o mutated.il
+
+ln -fs ../../test_eq.sby .
+sby -f test_eq.sby
+
+## obtain result
+gawk "{ print 1, \$1; }" test_eq/status >> output.txt
+
+exit 0

--- a/examples/SQED_ridecore/test_eq.sv
+++ b/examples/SQED_ridecore/test_eq.sv
@@ -1,0 +1,322 @@
+module miter #(
+        parameter DATA_LEN = 32,
+        parameter INST_LEN = 32,
+        parameter REG_SEL = 5,
+        parameter REG_NUM = 32
+)
+(
+        input din_clk,
+        input din_rst_n,
+        input ref_din_exec_dup,
+        input uut_din_exec_dup,
+        input [INST_LEN-1:0] ref_din_instruction,
+        input [INST_LEN-1:0] uut_din_instruction
+);
+        wire [DATA_LEN-1:0] ref_dout_gpr0;
+        wire [DATA_LEN-1:0] ref_dout_gpr1;
+        wire [DATA_LEN-1:0] ref_dout_gpr2;
+        wire [DATA_LEN-1:0] ref_dout_gpr3;
+        wire [DATA_LEN-1:0] ref_dout_gpr4;
+        wire [DATA_LEN-1:0] ref_dout_gpr5;
+        wire [DATA_LEN-1:0] ref_dout_gpr6;
+        wire [DATA_LEN-1:0] ref_dout_gpr7;
+        wire [DATA_LEN-1:0] ref_dout_gpr8;
+        wire [DATA_LEN-1:0] ref_dout_gpr9;
+        wire [DATA_LEN-1:0] ref_dout_gpr10;
+        wire [DATA_LEN-1:0] ref_dout_gpr11;
+        wire [DATA_LEN-1:0] ref_dout_gpr12;
+        wire [DATA_LEN-1:0] ref_dout_gpr13;
+        wire [DATA_LEN-1:0] ref_dout_gpr14;
+        wire [DATA_LEN-1:0] ref_dout_gpr15;
+        wire [DATA_LEN-1:0] ref_dout_gpr16;
+        wire [DATA_LEN-1:0] ref_dout_gpr17;
+        wire [DATA_LEN-1:0] ref_dout_gpr18;
+        wire [DATA_LEN-1:0] ref_dout_gpr19;
+        wire [DATA_LEN-1:0] ref_dout_gpr20;
+        wire [DATA_LEN-1:0] ref_dout_gpr21;
+        wire [DATA_LEN-1:0] ref_dout_gpr22;
+        wire [DATA_LEN-1:0] ref_dout_gpr23;
+        wire [DATA_LEN-1:0] ref_dout_gpr24;
+        wire [DATA_LEN-1:0] ref_dout_gpr25;
+        wire [DATA_LEN-1:0] ref_dout_gpr26;
+        wire [DATA_LEN-1:0] ref_dout_gpr27;
+        wire [DATA_LEN-1:0] ref_dout_gpr28;
+        wire [DATA_LEN-1:0] ref_dout_gpr29;
+        wire [DATA_LEN-1:0] ref_dout_gpr30;
+        wire [DATA_LEN-1:0] ref_dout_gpr31;
+        wire ref_dout_arfwe1;
+        wire ref_dout_arfwe2;
+        wire [REG_SEL-1:0] ref_dout_dstarf1;
+        wire [REG_SEL-1:0] ref_dout_dstarf2;
+        wire ref_dout_stall_IF; 
+
+        wire [DATA_LEN-1:0] uut_dout_gpr0;
+        wire [DATA_LEN-1:0] uut_dout_gpr1;
+        wire [DATA_LEN-1:0] uut_dout_gpr2;
+        wire [DATA_LEN-1:0] uut_dout_gpr3;
+        wire [DATA_LEN-1:0] uut_dout_gpr4;
+        wire [DATA_LEN-1:0] uut_dout_gpr5;
+        wire [DATA_LEN-1:0] uut_dout_gpr6;
+        wire [DATA_LEN-1:0] uut_dout_gpr7;
+        wire [DATA_LEN-1:0] uut_dout_gpr8;
+        wire [DATA_LEN-1:0] uut_dout_gpr9;
+        wire [DATA_LEN-1:0] uut_dout_gpr10;
+        wire [DATA_LEN-1:0] uut_dout_gpr11;
+        wire [DATA_LEN-1:0] uut_dout_gpr12;
+        wire [DATA_LEN-1:0] uut_dout_gpr13;
+        wire [DATA_LEN-1:0] uut_dout_gpr14;
+        wire [DATA_LEN-1:0] uut_dout_gpr15;
+        wire [DATA_LEN-1:0] uut_dout_gpr16;
+        wire [DATA_LEN-1:0] uut_dout_gpr17;
+        wire [DATA_LEN-1:0] uut_dout_gpr18;
+        wire [DATA_LEN-1:0] uut_dout_gpr19;
+        wire [DATA_LEN-1:0] uut_dout_gpr20;
+        wire [DATA_LEN-1:0] uut_dout_gpr21;
+        wire [DATA_LEN-1:0] uut_dout_gpr22;
+        wire [DATA_LEN-1:0] uut_dout_gpr23;
+        wire [DATA_LEN-1:0] uut_dout_gpr24;
+        wire [DATA_LEN-1:0] uut_dout_gpr25;
+        wire [DATA_LEN-1:0] uut_dout_gpr26;
+        wire [DATA_LEN-1:0] uut_dout_gpr27;
+        wire [DATA_LEN-1:0] uut_dout_gpr28;
+        wire [DATA_LEN-1:0] uut_dout_gpr29;
+        wire [DATA_LEN-1:0] uut_dout_gpr30;
+        wire [DATA_LEN-1:0] uut_dout_gpr31;
+        wire uut_dout_arfwe1;
+        wire uut_dout_arfwe2;
+        wire [REG_SEL-1:0] uut_dout_dstarf1;
+        wire [REG_SEL-1:0] uut_dout_dstarf2;
+        wire uut_dout_stall_IF;
+
+        //initial assume (din_rst_n == 1'b0);
+
+        // Use the inst_constraint module to constrain instruction to be
+        // a valid instruction from the ISA
+        inst_constraints ic (
+		.clk         (din_clk),
+                .instruction (ref_din_instruction)
+	);
+
+        always @ (posedge din_clk) begin
+                assume_same_instruction: assume property(ref_din_instruction == uut_din_instruction); 
+        end        
+
+        wire [INST_LEN-1:0] ref_qed_instruction;
+	(* kepp *) wire ref_qed_vld_out;
+        wire [INST_LEN-1:0] uut_qed_instruction;
+	(* keep *) wire uut_qed_vld_out;
+
+        // QED module: transforms the original instruction to duplicate instruction
+	qed ref_qed (
+		//Inputs
+		.clk(din_clk),
+		.rst(~din_rst_n),
+		.ena(1'b1),
+		.exec_dup(ref_din_exec_dup),
+		.ifu_qed_instruction(ref_din_instruction),
+		.stall_IF(ref_dout_stall_IF),
+
+		//Outputs
+		.qed_ifu_instruction(ref_qed_instruction),
+		.vld_out(ref_qed_vld_out)
+	);
+
+        qed uut_qed (
+		//Inputs
+		.clk(din_clk),
+		.rst(~din_rst_n),
+		.ena(1'b1),
+		.exec_dup(uut_din_exec_dup),
+		.ifu_qed_instruction(uut_din_instruction),
+		.stall_IF(uut_dout_stall_IF),
+
+		//Outputs
+		.qed_ifu_instruction(uut_qed_instruction),
+		.vld_out(uut_qed_vld_out)
+	);
+
+        // disable mutation
+        top_ridecore ref (
+                .mutsel         (1'b0),
+                .clk            (din_clk),
+		.reset_x  	(din_rst_n),
+		.qed_instruction(ref_qed_instruction),
+		.qed_vld_out    (ref_qed_vld_out),
+
+                .gpr0           (ref_dout_gpr0),
+                .gpr1           (ref_dout_gpr1),
+                .gpr2           (ref_dout_gpr2),
+                .gpr3           (ref_dout_gpr3),
+                .gpr4           (ref_dout_gpr4),
+                .gpr5           (ref_dout_gpr5),
+                .gpr6           (ref_dout_gpr6),
+                .gpr7           (ref_dout_gpr7),
+                .gpr8           (ref_dout_gpr8),
+                .gpr9           (ref_dout_gpr9),
+                .gpr10          (ref_dout_gpr10),
+                .gpr11          (ref_dout_gpr11),
+                .gpr12          (ref_dout_gpr12),
+                .gpr13          (ref_dout_gpr13),
+                .gpr14          (ref_dout_gpr14),
+                .gpr15          (ref_dout_gpr15),
+                .gpr16          (ref_dout_gpr16),
+                .gpr17          (ref_dout_gpr17),
+                .gpr18          (ref_dout_gpr18),
+                .gpr19          (ref_dout_gpr19),
+                .gpr20          (ref_dout_gpr20),
+                .gpr21          (ref_dout_gpr21),
+                .gpr22          (ref_dout_gpr22),
+                .gpr23          (ref_dout_gpr23),
+                .gpr24          (ref_dout_gpr24),
+                .gpr25          (ref_dout_gpr25),
+                .gpr26          (ref_dout_gpr26),
+                .gpr27          (ref_dout_gpr27),
+                .gpr28          (ref_dout_gpr28),
+                .gpr29          (ref_dout_gpr29),
+                .gpr30          (ref_dout_gpr30),
+                .gpr31          (ref_dout_gpr31),
+
+                .arfwe1         (ref_dout_arfwe1),
+		.arfwe2         (ref_dout_arfwe2),
+		.dstarf1        (ref_dout_dstarf1),
+		.dstarf2        (ref_dout_dstarf2),
+		.stall_IF       (ref_dout_stall_IF)
+
+        );
+
+        // enable mutation
+        top_ridecore uut (
+                .mutsel         (1'b1),
+                .clk            (din_clk),          
+                .reset_x  	(din_rst_n),
+		.qed_instruction(uut_qed_instruction),
+		.qed_vld_out    (uut_qed_vld_out),
+
+                .gpr0           (uut_dout_gpr0),
+                .gpr1           (uut_dout_gpr1),
+                .gpr2           (uut_dout_gpr2),
+                .gpr3           (uut_dout_gpr3),
+                .gpr4           (uut_dout_gpr4),
+                .gpr5           (uut_dout_gpr5),
+                .gpr6           (uut_dout_gpr6),
+                .gpr7           (uut_dout_gpr7),
+                .gpr8           (uut_dout_gpr8),
+                .gpr9           (uut_dout_gpr9),
+                .gpr10          (uut_dout_gpr10),
+                .gpr11          (uut_dout_gpr11),
+                .gpr12          (uut_dout_gpr12),
+                .gpr13          (uut_dout_gpr13),
+                .gpr14          (uut_dout_gpr14),
+                .gpr15          (uut_dout_gpr15),
+                .gpr16          (uut_dout_gpr16),
+                .gpr17          (uut_dout_gpr17),
+                .gpr18          (uut_dout_gpr18),
+                .gpr19          (uut_dout_gpr19),
+                .gpr20          (uut_dout_gpr20),
+                .gpr21          (uut_dout_gpr21),
+                .gpr22          (uut_dout_gpr22),
+                .gpr23          (uut_dout_gpr23),
+                .gpr24          (uut_dout_gpr24),
+                .gpr25          (uut_dout_gpr25),
+                .gpr26          (uut_dout_gpr26),
+                .gpr27          (uut_dout_gpr27),
+                .gpr28          (uut_dout_gpr28),
+                .gpr29          (uut_dout_gpr29),
+                .gpr30          (uut_dout_gpr30),
+                .gpr31          (uut_dout_gpr31),
+
+                .arfwe1         (uut_dout_arfwe1),
+		.arfwe2         (uut_dout_arfwe2),
+		.dstarf1        (uut_dout_dstarf1),
+		.dstarf2        (uut_dout_dstarf2),
+		.stall_IF       (uut_dout_stall_IF)
+        );
+
+        reg [15:0] ref_dout_comnum;
+        reg [15:0] uut_dout_comnum;
+        wire [1:0] ref_dout_commits;
+        wire [1:0] uut_dout_commits;
+
+        assign ref_dout_commits = (ref_dout_arfwe1 && ref_dout_arfwe2) ? 2'b10: 
+                                  (ref_dout_arfwe1 || ref_dout_arfwe2) ? 2'b01:
+                                                                         2'b00;
+
+        assign uut_dout_commits = (uut_dout_arfwe1 && uut_dout_arfwe2) ? 2'b10: 
+                                  (uut_dout_arfwe1 || uut_dout_arfwe2) ? 2'b01:
+                                                                         2'b00;                                                                 
+
+
+        always @(posedge din_clk) begin
+                if (~din_rst_n) begin
+                        ref_dout_comnum <= 0;
+                        uut_dout_comnum <= 0;
+                end else begin
+                        ref_dout_comnum <= ref_dout_comnum + {14'b0, ref_dout_commits};
+                        uut_dout_comnum <= uut_dout_comnum + {14'b0, uut_dout_commits};
+                end
+        end
+
+        always @(posedge din_clk) begin
+                if (din_rst_n) begin
+                   assume (ref_din_exec_dup == uut_din_exec_dup);
+                   if(ref_dout_comnum == uut_dout_comnum) begin
+                                assert (ref_dout_gpr0 == uut_dout_gpr0);
+                                assert (ref_dout_gpr1 == uut_dout_gpr1);
+                                assert (ref_dout_gpr2 == uut_dout_gpr2);
+                                assert (ref_dout_gpr3 == uut_dout_gpr3);
+                                assert (ref_dout_gpr4 == uut_dout_gpr4);
+                                assert (ref_dout_gpr5 == uut_dout_gpr5);
+                                assert (ref_dout_gpr6 == uut_dout_gpr6);
+                                assert (ref_dout_gpr7 == uut_dout_gpr7);
+                                assert (ref_dout_gpr8 == uut_dout_gpr8);
+                                assert (ref_dout_gpr9 == uut_dout_gpr9);
+                                assert (ref_dout_gpr10 == uut_dout_gpr10);
+                                assert (ref_dout_gpr11 == uut_dout_gpr11);
+                                assert (ref_dout_gpr12 == uut_dout_gpr12);
+                                assert (ref_dout_gpr13 == uut_dout_gpr13);
+                                assert (ref_dout_gpr14 == uut_dout_gpr14);
+                                assert (ref_dout_gpr15 == uut_dout_gpr15);
+                                assert (ref_dout_gpr16 == uut_dout_gpr16);
+                                assert (ref_dout_gpr17 == uut_dout_gpr17);
+                                assert (ref_dout_gpr18 == uut_dout_gpr18);
+                                assert (ref_dout_gpr19 == uut_dout_gpr19);
+                                assert (ref_dout_gpr20 == uut_dout_gpr20);
+                                assert (ref_dout_gpr21 == uut_dout_gpr21);
+                                assert (ref_dout_gpr22 == uut_dout_gpr22);
+                                assert (ref_dout_gpr23 == uut_dout_gpr23);
+                                assert (ref_dout_gpr24 == uut_dout_gpr24);
+                                assert (ref_dout_gpr25 == uut_dout_gpr25);
+                                assert (ref_dout_gpr26 == uut_dout_gpr26);
+                                assert (ref_dout_gpr27 == uut_dout_gpr27);
+                                assert (ref_dout_gpr28 == uut_dout_gpr28);
+                                assert (ref_dout_gpr29 == uut_dout_gpr29);
+                                assert (ref_dout_gpr30 == uut_dout_gpr30);
+                                assert (ref_dout_gpr31 == uut_dout_gpr31);
+                        end
+                end
+        end
+
+        // For debug
+        (* keep *) integer timecount; 
+        (* keep *) wire timeout; //if timeout, force to quit
+        always @(posedge din_clk) begin
+                if(~din_rst_n) begin
+                        timecount <= 0;
+                end 
+                else begin
+                        timecount <= timecount + 1;
+                end
+        end
+
+        assign timeout = (timecount > 8);
+        
+        // always @(posedge din_clk) begin
+        //         if (timeout) begin
+        //                 debug: assert property (1'b0);
+        //         end
+        // end
+
+
+endmodule
+
+`default_nettype wire

--- a/examples/SQED_ridecore/test_fm.sv
+++ b/examples/SQED_ridecore/test_fm.sv
@@ -1,0 +1,182 @@
+/*
+ *  Copyright (C) 2025 Yufeng Li <crazybinary494@gmail.com>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+module testbench #(
+	parameter DATA_LEN = 32,
+    parameter INST_LEN = 32,
+    parameter REG_SEL = 5,
+    parameter REG_NUM = 32
+)
+(
+	input din_clk,  
+	input din_rst_n,
+	input [INST_LEN-1:0] din_instruction,
+	input din_exec_dup
+);
+	wire [DATA_LEN-1:0] dout_gpr0;
+	wire [DATA_LEN-1:0] dout_gpr1;
+	wire [DATA_LEN-1:0] dout_gpr2;
+	wire [DATA_LEN-1:0] dout_gpr3;
+	wire [DATA_LEN-1:0] dout_gpr4;
+	wire [DATA_LEN-1:0] dout_gpr5;
+	wire [DATA_LEN-1:0] dout_gpr6;
+	wire [DATA_LEN-1:0] dout_gpr7;
+	wire [DATA_LEN-1:0] dout_gpr8;
+	wire [DATA_LEN-1:0] dout_gpr9;
+	wire [DATA_LEN-1:0] dout_gpr10;
+	wire [DATA_LEN-1:0] dout_gpr11;
+	wire [DATA_LEN-1:0] dout_gpr12;
+	wire [DATA_LEN-1:0] dout_gpr13;
+	wire [DATA_LEN-1:0] dout_gpr14;
+	wire [DATA_LEN-1:0] dout_gpr15;
+	wire [DATA_LEN-1:0] dout_gpr16;
+	wire [DATA_LEN-1:0] dout_gpr17;
+	wire [DATA_LEN-1:0] dout_gpr18;
+	wire [DATA_LEN-1:0] dout_gpr19;
+	wire [DATA_LEN-1:0] dout_gpr20;
+	wire [DATA_LEN-1:0] dout_gpr21;
+	wire [DATA_LEN-1:0] dout_gpr22;
+	wire [DATA_LEN-1:0] dout_gpr23;
+	wire [DATA_LEN-1:0] dout_gpr24;
+	wire [DATA_LEN-1:0] dout_gpr25;
+	wire [DATA_LEN-1:0] dout_gpr26;
+	wire [DATA_LEN-1:0] dout_gpr27;
+	wire [DATA_LEN-1:0] dout_gpr28;
+	wire [DATA_LEN-1:0] dout_gpr29;
+	wire [DATA_LEN-1:0] dout_gpr30;
+	wire [DATA_LEN-1:0] dout_gpr31;
+	wire dout_arfwe1;
+	wire dout_arfwe2;
+	wire [REG_SEL-1:0] dout_dstarf1;
+	wire [REG_SEL-1:0] dout_dstarf2;
+	wire dout_stall_IF;
+
+	// Use the inst_constraint module to constrain instruction to be
+    // a valid instruction from the ISA
+    inst_constraints ic (
+		.clk         (din_clk),
+        .instruction (din_instruction)
+	);
+
+	wire [INST_LEN-1:0] qed_instruction;
+	wire qed_vld_out;
+
+	// QED module: transforms the original instruction 
+	qed qed0 (
+		// Inputs
+		.clk(din_clk),
+		.rst(~din_rst_n),
+		.ena(1'b1),
+		.exec_dup(din_exec_dup),
+		.ifu_qed_instruction(din_instruction),
+		.stall_IF(dout_stall_IF),
+
+		// Outputs
+		.qed_ifu_instruction(qed_instruction),
+		.vld_out(qed_vld_out)
+	);
+
+	top_ridecore duv (
+		.clk         (din_clk),
+		.reset_x  	 (din_rst_n),
+		.qed_instruction (qed_instruction),
+		.qed_vld_out (qed_vld_out),
+
+		.gpr0        (dout_gpr0),
+		.gpr1        (dout_gpr1),
+		.gpr2        (dout_gpr2),
+		.gpr3        (dout_gpr3),
+		.gpr4        (dout_gpr4),
+		.gpr5        (dout_gpr5),
+		.gpr6        (dout_gpr6),
+		.gpr7        (dout_gpr7),
+		.gpr8        (dout_gpr8),
+		.gpr9        (dout_gpr9),
+		.gpr10       (dout_gpr10),
+		.gpr11       (dout_gpr11),
+		.gpr12       (dout_gpr12),
+		.gpr13       (dout_gpr13),
+		.gpr14       (dout_gpr14),
+		.gpr15       (dout_gpr15),
+		.gpr16       (dout_gpr16),
+		.gpr17       (dout_gpr17),
+		.gpr18       (dout_gpr18),
+		.gpr19       (dout_gpr19),
+		.gpr20       (dout_gpr20),
+		.gpr21       (dout_gpr21),
+		.gpr22       (dout_gpr22),
+		.gpr23       (dout_gpr23),
+		.gpr24       (dout_gpr24),
+		.gpr25       (dout_gpr25),
+		.gpr26       (dout_gpr26),
+		.gpr27       (dout_gpr27),
+		.gpr28       (dout_gpr28),
+		.gpr29       (dout_gpr29),
+		.gpr30       (dout_gpr30),
+		.gpr31       (dout_gpr31),
+		.arfwe1      (dout_arfwe1),
+		.arfwe2      (dout_arfwe2),
+		.dstarf1     (dout_dstarf1),
+		.dstarf2     (dout_dstarf2),
+		.stall_IF    (dout_stall_IF)
+	);
+
+	properties p (
+		.clk (din_clk),
+		.rst (~din_rst_n),
+		.reg_val0 (dout_gpr0),
+		.reg_val1 (dout_gpr1),
+		.reg_val2 (dout_gpr2),
+		.reg_val3 (dout_gpr3),
+		.reg_val4 (dout_gpr4),
+		.reg_val5 (dout_gpr5),
+		.reg_val6 (dout_gpr6),
+		.reg_val7 (dout_gpr7),
+		.reg_val8 (dout_gpr8),
+		.reg_val9 (dout_gpr9),
+		.reg_val10 (dout_gpr10),
+		.reg_val11 (dout_gpr11),
+		.reg_val12 (dout_gpr12),
+		.reg_val13 (dout_gpr13),
+		.reg_val14 (dout_gpr14),
+		.reg_val15 (dout_gpr15),
+		.reg_val16 (dout_gpr16),
+		.reg_val17 (dout_gpr17),
+		.reg_val18 (dout_gpr18),
+		.reg_val19 (dout_gpr19),
+		.reg_val20 (dout_gpr20),
+		.reg_val21 (dout_gpr21),
+		.reg_val22 (dout_gpr22),
+		.reg_val23 (dout_gpr23),
+		.reg_val24 (dout_gpr24),
+		.reg_val25 (dout_gpr25),
+		.reg_val26 (dout_gpr26),
+		.reg_val27 (dout_gpr27),
+		.reg_val28 (dout_gpr28),
+		.reg_val29 (dout_gpr29),
+		.reg_val30 (dout_gpr30),
+		.reg_val31 (dout_gpr31),
+		.arfwe1 (dout_arfwe1),
+		.arfwe2 (dout_arfwe2),
+		.dstarf1 (dout_dstarf1),
+		.dstarf2 (dout_dstarf2)
+	);
+
+
+endmodule
+
+`default_nettype wire


### PR DESCRIPTION
A use case targeting the ridecore out-of-order processor has been added in the "examples/" directory, where mcy is used to evaluate the coverage of the SQED formal verification method.